### PR TITLE
Python 3 compatibility

### DIFF
--- a/evaluators/beat_eval.py
+++ b/evaluators/beat_eval.py
@@ -10,6 +10,7 @@ Usage:
 ./beat_eval.py REFERENCE.TXT ESTIMATED.TXT
 '''
 
+from __future__ import print_function
 import argparse
 import sys
 import os
@@ -50,10 +51,10 @@ if __name__ == '__main__':
     estimated_beats = mir_eval.io.load_events(parameters['estimated_file'])
     # Compute all the scores
     scores = mir_eval.beat.evaluate(reference_beats, estimated_beats)
-    print "{} vs. {}".format(os.path.basename(parameters['reference_file']),
-                             os.path.basename(parameters['estimated_file']))
+    print("{} vs. {}".format(os.path.basename(parameters['reference_file']),
+                             os.path.basename(parameters['estimated_file'])))
     eval_utilities.print_evaluation(scores)
 
     if parameters['output_file']:
-        print 'Saving results to: ', parameters['output_file']
+        print('Saving results to: ', parameters['output_file'])
         eval_utilities.save_results(scores, parameters['output_file'])

--- a/evaluators/chord_eval.py
+++ b/evaluators/chord_eval.py
@@ -8,6 +8,7 @@ Usage:
 ./chord_eval.py TRUTH.TXT PREDICTION.TXT
 '''
 
+from __future__ import print_function
 import argparse
 import sys
 import os
@@ -52,10 +53,10 @@ if __name__ == '__main__':
     # Compute all the scores
     scores = mir_eval.chord.evaluate(ref_intervals, ref_labels,
                                      est_intervals, est_labels)
-    print "{} vs. {}".format(os.path.basename(parameters['reference_file']),
-                             os.path.basename(parameters['estimated_file']))
+    print("{} vs. {}".format(os.path.basename(parameters['reference_file']),
+                             os.path.basename(parameters['estimated_file'])))
     eval_utilities.print_evaluation(scores)
 
     if parameters['output_file']:
-        print 'Saving results to: ', parameters['output_file']
+        print('Saving results to: ', parameters['output_file'])
         eval_utilities.save_results(scores, parameters['output_file'])

--- a/evaluators/eval_utilities.py
+++ b/evaluators/eval_utilities.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from future.utils import iteritems
 import json
 
 
@@ -26,8 +28,8 @@ def print_evaluation(results):
             the corresponding scores
     '''
     max_len = max([len(key) for key in results])
-    for key, value in results.iteritems():
+    for key, value in iteritems(results):
         if type(value) == float:
-            print '\t{:>{}} : {:.3f}'.format(key, max_len, value)
+            print('\t{:>{}} : {:.3f}'.format(key, max_len, value))
         else:
-            print '\t{:>{}} : {}'.format(key, max_len, value)
+            print('\t{:>{}} : {}'.format(key, max_len, value))

--- a/evaluators/melody_eval.py
+++ b/evaluators/melody_eval.py
@@ -16,6 +16,7 @@ from Polyphonic Music Signals: Approaches, Applications and Challenges",
 IEEE Signal Processing Magazine, 31(2):118-134, Mar. 2014.
 '''
 
+from __future__ import print_function
 import argparse
 import sys
 import os
@@ -68,10 +69,10 @@ if __name__ == '__main__':
     # Compute all the scores
     scores = mir_eval.melody.evaluate(ref_time, ref_freq, est_time, est_freq,
                                       hop=parameters['hop'])
-    print "{} vs. {}".format(os.path.basename(parameters['reference_file']),
-                             os.path.basename(parameters['estimated_file']))
+    print("{} vs. {}".format(os.path.basename(parameters['reference_file']),
+                             os.path.basename(parameters['estimated_file'])))
     eval_utilities.print_evaluation(scores)
 
     if parameters['output_file']:
-        print 'Saving results to: ', parameters['output_file']
+        print('Saving results to: ', parameters['output_file'])
         eval_utilities.save_results(scores, parameters['output_file'])

--- a/evaluators/onset_eval.py
+++ b/evaluators/onset_eval.py
@@ -7,6 +7,7 @@ Usage:
 ./onset_eval.py REFERENCE.TXT ESTIMATED.TXT
 '''
 
+from __future__ import print_function
 import argparse
 import sys
 import os
@@ -48,10 +49,10 @@ if __name__ == '__main__':
 
     # Compute all the scores
     scores = mir_eval.onset.evaluate(reference_onsets, estimated_onsets)
-    print "{} vs. {}".format(os.path.basename(parameters['reference_file']),
-                             os.path.basename(parameters['estimated_file']))
+    print("{} vs. {}".format(os.path.basename(parameters['reference_file']),
+                             os.path.basename(parameters['estimated_file'])))
     eval_utilities.print_evaluation(scores)
 
     if parameters['output_file']:
-        print 'Saving results to: ', parameters['output_file']
+        print('Saving results to: ', parameters['output_file'])
         eval_utilities.save_results(scores, parameters['output_file'])

--- a/evaluators/pattern_eval.py
+++ b/evaluators/pattern_eval.py
@@ -12,6 +12,7 @@ Example:
 Written by Oriol Nieto (oriol@nyu.edu), 2014
 """
 
+from __future__ import print_function
 import argparse
 import os
 import sys
@@ -45,12 +46,12 @@ def main():
 
     # Compute all the scores
     scores = mir_eval.pattern.evaluate(ref_patterns, est_patterns)
-    print "{} vs. {}".format(os.path.basename(parameters['reference_file']),
-                             os.path.basename(parameters['estimated_file']))
+    print("{} vs. {}".format(os.path.basename(parameters['reference_file']),
+                             os.path.basename(parameters['estimated_file'])))
     eval_utilities.print_evaluation(scores)
 
     if parameters['output_file']:
-        print 'Saving results to: ', parameters['output_file']
+        print('Saving results to: ', parameters['output_file'])
         eval_utilities.save_results(scores, parameters['output_file'])
 
 

--- a/evaluators/segment_eval.py
+++ b/evaluators/segment_eval.py
@@ -9,6 +9,7 @@ Usage:
 ./segment_eval.py TRUTH.TXT PREDICTION.TXT
 '''
 
+from __future__ import print_function
 import argparse
 import sys
 import os
@@ -63,10 +64,10 @@ if __name__ == '__main__':
     scores = mir_eval.segment.evaluate(ref_intervals, ref_labels,
                                        est_intervals, est_labels,
                                        trim=parameters['trim'])
-    print "{} vs. {}".format(os.path.basename(parameters['reference_file']),
-                             os.path.basename(parameters['estimated_file']))
+    print("{} vs. {}".format(os.path.basename(parameters['reference_file']),
+                             os.path.basename(parameters['estimated_file'])))
     eval_utilities.print_evaluation(scores)
 
     if parameters['output_file']:
-        print 'Saving results to: ', parameters['output_file']
+        print('Saving results to: ', parameters['output_file'])
         eval_utilities.save_results(scores, parameters['output_file'])

--- a/evaluators/separation_eval.py
+++ b/evaluators/separation_eval.py
@@ -7,6 +7,7 @@ Usage:
 ./separation_eval.py PATH_TO_REFERENCE_WAVS PATH_TO_ESTIMATED_WAVS
 '''
 
+from __future__ import print_function
 import argparse
 import sys
 import os
@@ -73,10 +74,10 @@ if __name__ == '__main__':
     # Compute all the scores
     scores = mir_eval.separation.evaluate(reference_sources, estimated_sources)
     last_dir = lambda d: os.path.basename(os.path.normpath(d))
-    print "{} vs. {}".format(last_dir(parameters['reference_directory']),
-                             last_dir(parameters['estimated_directory']))
+    print("{} vs. {}".format(last_dir(parameters['reference_directory']),
+                             last_dir(parameters['estimated_directory'])))
     eval_utilities.print_evaluation(scores)
 
     if parameters['output_file']:
-        print 'Saving results to: ', parameters['output_file']
+        print('Saving results to: ', parameters['output_file'])
         eval_utilities.save_results(scores, parameters['output_file'])

--- a/mir_eval/beat.py
+++ b/mir_eval/beat.py
@@ -53,6 +53,11 @@ import warnings
 # The maximum allowable beat time
 MAX_TIME = 30000.
 
+try:
+    xrange
+except NameError:
+    xrange = range
+
 
 def trim_beats(beats, min_beat_time=5.):
     '''Removes beats before min_beat_time.  A common preprocessing step.

--- a/mir_eval/io.py
+++ b/mir_eval/io.py
@@ -9,6 +9,11 @@ import scipy.io.wavfile
 
 from . import util
 
+try:
+    xrange
+except NameError:
+    xrange = range
+
 
 def load_delimited(filename, converters, delimiter=r'\s+'):
     '''

--- a/mir_eval/pattern.py
+++ b/mir_eval/pattern.py
@@ -62,6 +62,11 @@ from . import util
 import warnings
 import collections
 
+try:
+    xrange
+except NameError:
+    xrange = range
+
 
 def _n_onset_midi(patterns):
     ''' Computes the number of onset_midi objects in a pattern '''

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -40,6 +40,11 @@ import itertools
 import warnings
 from . import util
 
+try:
+    xrange
+except NameError:
+    xrange = range
+
 
 # The maximum allowable number of sources (prevents insane computational load)
 MAX_SOURCES = 100

--- a/mir_eval/util.py
+++ b/mir_eval/util.py
@@ -7,6 +7,11 @@ import numpy as np
 import os
 import inspect
 
+try:
+    xrange
+except NameError:
+    xrange = range
+
 
 def index_labels(labels, case_sensitive=False):
     '''Convert a list of string identifiers into numerical indices.
@@ -211,7 +216,7 @@ def boundaries_to_intervals(boundaries, labels=None):
     if not np.allclose(boundaries, np.unique(boundaries)):
         raise ValueError('Boundary times are not unique or not ascending.')
 
-    intervals = np.asarray(zip(boundaries[:-1], boundaries[1:]))
+    intervals = np.asarray(list(zip(boundaries[:-1], boundaries[1:])))
 
     if labels is None:
         interval_labels = None
@@ -656,7 +661,7 @@ def filter_kwargs(function, *args, **kwargs):
     function_args = inspect.getargspec(function).args
     # Construct a dict of those kwargs which appear in the function
     filtered_kwargs = {}
-    for kwarg, value in kwargs.items():
+    for kwarg, value in list(kwargs.items()):
         if kwarg in function_args:
             filtered_kwargs[kwarg] = value
     # Call the function with the supplied args and the filtered kwarg dict

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,8 @@ setup(
         'Development Status :: 5 - Production/Stable',
         "Intended Audience :: Developers",
         "Topic :: Multimedia :: Sound/Audio :: Analysis",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
     ],
     keywords='audio music mir dsp',
     license='MIT',

--- a/tests/generate_data.py
+++ b/tests/generate_data.py
@@ -19,6 +19,7 @@ So, for example, if you'd like to generate data for onset and melody,run
     ./generate_data.py onset melody
 '''
 
+from __future__ import print_function
 import mir_eval
 import glob
 import json
@@ -66,7 +67,7 @@ if __name__ == '__main__':
                            'data/separation/{}*')
     # Get task keys from argv
     for task in sys.argv[1:]:
-        print 'Generating data for {}'.format(task)
+        print('Generating data for {}'.format(task))
         submodule, loader, data_glob = tasks[task]
         # Cycle through annotation file pairs
         for ref_file, est_file in zip(glob.glob(data_glob.format('ref')),


### PR DESCRIPTION
This branch makes mir_eval compatible with Python 3. Nothing fancy, mainl `print` and `xargs` were acting up.

The only bigger thing was in `evaluators/eval_utilities.py`. In Python 3 `dict.items()` was always an iterable, while in Python 2 you had to explicitly call `dict.iteritems()`. There is a function `iteritems` in `future.utils` that implements it cross-version.