### PR TITLE
Fix tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,8 @@ Python library for computing common heuristic accuracy scores for various music/
 
 Documentation, including installation and usage information: http://craffel.github.io/mir_eval/
 
+If you're looking for the mir_eval web service, which you can use to run mir_eval without installing anything or writing any code, it can be found here: http://labrosa.ee.columbia.edu/mir_eval/
+
 Dependencies:
 
 * `Scipy/Numpy <http://www.scipy.org/>`_

--- a/tests/test_chord.py
+++ b/tests/test_chord.py
@@ -89,11 +89,11 @@ def test_join():
     # Arguments are root, quality, extensions, bass
     splits = [('F#', '', None, ''),
               ('F#', 'hdim7', None, ''),
-              ('F#', '', {'*b3', '4'}, ''),
+              ('F#', '', ['*b3', '4'], ''),
               ('F#', '', None, 'b7'),
-              ('F#', '', {'*b3', '4'}, 'b7'),
+              ('F#', '', ['*b3', '4'], 'b7'),
               ('F#', 'hdim7', None, 'b7'),
-              ('F#', 'hdim7', {'*b3', '4'}, 'b7')]
+              ('F#', 'hdim7', ['*b3', '4'], 'b7')]
     labels = ['F#', 'F#:hdim7', 'F#:(*b3,4)', 'F#/b7',
               'F#:(*b3,4)/b7', 'F#:hdim7/b7', 'F#:hdim7(*b3,4)/b7']
 

--- a/tests/test_melody.py
+++ b/tests/test_melody.py
@@ -13,9 +13,9 @@ import warnings
 A_TOL = 1e-12
 
 # Path to the fixture files
-REF_GLOB = 'data/melody/ref*.txt'
-EST_GLOB = 'data/melody/est*.txt'
-SCORES_GLOB = 'data/melody/output*.json'
+REF_GLOB = 'tests/data/melody/ref*.txt'
+EST_GLOB = 'tests/data/melody/est*.txt'
+SCORES_GLOB = 'tests/data/melody/output*.json'
 
 
 def test_hz2cents():


### PR DESCRIPTION
There were two issues with the tests:

Running `nosetests` from the root directory of the project failed as the scripts could not find the testdata. Prepending `tests/` to their path fixed the issue.

Also, there was an error only showing up intermittently: 

    ======================================================================
    FAIL: test_chord.test_join(<function join at 0x7f9dcc65ec80>, ('F#', '', {'4', '*b3'}, 'b7'), 'F#:(*b3,4)/b7')
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/usr/lib/python3.4/site-packages/nose/case.py", line 198, in runTest
        self.test(*self.arg)
      File "/home/nils/Arbeit/mireval3/mir_eval/tests/test_chord.py", line 22, in __check_valid
        assert function(*parameters) == result
    AssertionError

This had to do with the testdata being wrapped in `dict`s where they should've been in `lists` as `dict`s are not ordered. In some of the testruns the order of the arguments were reversed and the string comparison failed.