### PR TITLE
Travis CI + Python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: python
+python:
+    - "2.7"
+    - "3.3"
+#    - "3.4" # not supported due to no scipy wheel available yet
+install:
+    - sudo apt-get update -qq
+    - sudo apt-get install -qq libatlas-base-dev libatlas3gf-base gfortran
+
+# Install NumPy and SciPy from wheels, as compilation takes ages
+# This should be wheels.astropy.org, but there are strange HTTPS errors a.t.m.
+    - pip install --no-index --find-links http://www.mpia.de/~robitaille/wheelhouse/ --trusted-host www.mpia.de scipy
+    - pip install -e .
+    - pip install nose sphinx numpydoc
+script:
+    - nosetests
+    - python setup.py build_sphinx
+    - python setup.py egg_info -b.dev sdist --formats gztar

--- a/evaluators/beat_eval.py
+++ b/evaluators/beat_eval.py
@@ -10,6 +10,7 @@ Usage:
 ./beat_eval.py REFERENCE.TXT ESTIMATED.TXT
 '''
 
+from __future__ import print_function
 import argparse
 import sys
 import os
@@ -50,10 +51,10 @@ if __name__ == '__main__':
     estimated_beats = mir_eval.io.load_events(parameters['estimated_file'])
     # Compute all the scores
     scores = mir_eval.beat.evaluate(reference_beats, estimated_beats)
-    print "{} vs. {}".format(os.path.basename(parameters['reference_file']),
-                             os.path.basename(parameters['estimated_file']))
+    print("{} vs. {}".format(os.path.basename(parameters['reference_file']),
+                             os.path.basename(parameters['estimated_file'])))
     eval_utilities.print_evaluation(scores)
 
     if parameters['output_file']:
-        print 'Saving results to: ', parameters['output_file']
+        print('Saving results to: ', parameters['output_file'])
         eval_utilities.save_results(scores, parameters['output_file'])

--- a/evaluators/chord_eval.py
+++ b/evaluators/chord_eval.py
@@ -8,6 +8,7 @@ Usage:
 ./chord_eval.py TRUTH.TXT PREDICTION.TXT
 '''
 
+from __future__ import print_function
 import argparse
 import sys
 import os
@@ -52,10 +53,10 @@ if __name__ == '__main__':
     # Compute all the scores
     scores = mir_eval.chord.evaluate(ref_intervals, ref_labels,
                                      est_intervals, est_labels)
-    print "{} vs. {}".format(os.path.basename(parameters['reference_file']),
-                             os.path.basename(parameters['estimated_file']))
+    print("{} vs. {}".format(os.path.basename(parameters['reference_file']),
+                             os.path.basename(parameters['estimated_file'])))
     eval_utilities.print_evaluation(scores)
 
     if parameters['output_file']:
-        print 'Saving results to: ', parameters['output_file']
+        print('Saving results to: ', parameters['output_file'])
         eval_utilities.save_results(scores, parameters['output_file'])

--- a/evaluators/eval_utilities.py
+++ b/evaluators/eval_utilities.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from future.utils import iteritems
 import json
 
 
@@ -26,8 +28,8 @@ def print_evaluation(results):
             the corresponding scores
     '''
     max_len = max([len(key) for key in results])
-    for key, value in results.iteritems():
+    for key, value in iteritems(results):
         if type(value) == float:
-            print '\t{:>{}} : {:.3f}'.format(key, max_len, value)
+            print('\t{:>{}} : {:.3f}'.format(key, max_len, value))
         else:
-            print '\t{:>{}} : {}'.format(key, max_len, value)
+            print('\t{:>{}} : {}'.format(key, max_len, value))

--- a/evaluators/melody_eval.py
+++ b/evaluators/melody_eval.py
@@ -16,6 +16,7 @@ from Polyphonic Music Signals: Approaches, Applications and Challenges",
 IEEE Signal Processing Magazine, 31(2):118-134, Mar. 2014.
 '''
 
+from __future__ import print_function
 import argparse
 import sys
 import os
@@ -68,10 +69,10 @@ if __name__ == '__main__':
     # Compute all the scores
     scores = mir_eval.melody.evaluate(ref_time, ref_freq, est_time, est_freq,
                                       hop=parameters['hop'])
-    print "{} vs. {}".format(os.path.basename(parameters['reference_file']),
-                             os.path.basename(parameters['estimated_file']))
+    print("{} vs. {}".format(os.path.basename(parameters['reference_file']),
+                             os.path.basename(parameters['estimated_file'])))
     eval_utilities.print_evaluation(scores)
 
     if parameters['output_file']:
-        print 'Saving results to: ', parameters['output_file']
+        print('Saving results to: ', parameters['output_file'])
         eval_utilities.save_results(scores, parameters['output_file'])

--- a/evaluators/onset_eval.py
+++ b/evaluators/onset_eval.py
@@ -7,6 +7,7 @@ Usage:
 ./onset_eval.py REFERENCE.TXT ESTIMATED.TXT
 '''
 
+from __future__ import print_function
 import argparse
 import sys
 import os
@@ -48,10 +49,10 @@ if __name__ == '__main__':
 
     # Compute all the scores
     scores = mir_eval.onset.evaluate(reference_onsets, estimated_onsets)
-    print "{} vs. {}".format(os.path.basename(parameters['reference_file']),
-                             os.path.basename(parameters['estimated_file']))
+    print("{} vs. {}".format(os.path.basename(parameters['reference_file']),
+                             os.path.basename(parameters['estimated_file'])))
     eval_utilities.print_evaluation(scores)
 
     if parameters['output_file']:
-        print 'Saving results to: ', parameters['output_file']
+        print('Saving results to: ', parameters['output_file'])
         eval_utilities.save_results(scores, parameters['output_file'])

--- a/evaluators/pattern_eval.py
+++ b/evaluators/pattern_eval.py
@@ -12,6 +12,7 @@ Example:
 Written by Oriol Nieto (oriol@nyu.edu), 2014
 """
 
+from __future__ import print_function
 import argparse
 import os
 import sys
@@ -45,12 +46,12 @@ def main():
 
     # Compute all the scores
     scores = mir_eval.pattern.evaluate(ref_patterns, est_patterns)
-    print "{} vs. {}".format(os.path.basename(parameters['reference_file']),
-                             os.path.basename(parameters['estimated_file']))
+    print("{} vs. {}".format(os.path.basename(parameters['reference_file']),
+                             os.path.basename(parameters['estimated_file'])))
     eval_utilities.print_evaluation(scores)
 
     if parameters['output_file']:
-        print 'Saving results to: ', parameters['output_file']
+        print('Saving results to: ', parameters['output_file'])
         eval_utilities.save_results(scores, parameters['output_file'])
 
 

--- a/evaluators/segment_eval.py
+++ b/evaluators/segment_eval.py
@@ -9,6 +9,7 @@ Usage:
 ./segment_eval.py TRUTH.TXT PREDICTION.TXT
 '''
 
+from __future__ import print_function
 import argparse
 import sys
 import os
@@ -63,10 +64,10 @@ if __name__ == '__main__':
     scores = mir_eval.segment.evaluate(ref_intervals, ref_labels,
                                        est_intervals, est_labels,
                                        trim=parameters['trim'])
-    print "{} vs. {}".format(os.path.basename(parameters['reference_file']),
-                             os.path.basename(parameters['estimated_file']))
+    print("{} vs. {}".format(os.path.basename(parameters['reference_file']),
+                             os.path.basename(parameters['estimated_file'])))
     eval_utilities.print_evaluation(scores)
 
     if parameters['output_file']:
-        print 'Saving results to: ', parameters['output_file']
+        print('Saving results to: ', parameters['output_file'])
         eval_utilities.save_results(scores, parameters['output_file'])

--- a/evaluators/separation_eval.py
+++ b/evaluators/separation_eval.py
@@ -7,6 +7,7 @@ Usage:
 ./separation_eval.py PATH_TO_REFERENCE_WAVS PATH_TO_ESTIMATED_WAVS
 '''
 
+from __future__ import print_function
 import argparse
 import sys
 import os
@@ -73,10 +74,10 @@ if __name__ == '__main__':
     # Compute all the scores
     scores = mir_eval.separation.evaluate(reference_sources, estimated_sources)
     last_dir = lambda d: os.path.basename(os.path.normpath(d))
-    print "{} vs. {}".format(last_dir(parameters['reference_directory']),
-                             last_dir(parameters['estimated_directory']))
+    print("{} vs. {}".format(last_dir(parameters['reference_directory']),
+                             last_dir(parameters['estimated_directory'])))
     eval_utilities.print_evaluation(scores)
 
     if parameters['output_file']:
-        print 'Saving results to: ', parameters['output_file']
+        print('Saving results to: ', parameters['output_file'])
         eval_utilities.save_results(scores, parameters['output_file'])

--- a/mir_eval/beat.py
+++ b/mir_eval/beat.py
@@ -53,11 +53,6 @@ import warnings
 # The maximum allowable beat time
 MAX_TIME = 30000.
 
-try:
-    xrange
-except NameError:
-    xrange = range
-
 
 def trim_beats(beats, min_beat_time=5.):
     """Removes beats before min_beat_time.  A common preprocessing step.
@@ -287,7 +282,7 @@ def goto(reference_beats,
     paired = np.zeros(reference_beats.shape[0])
     # Keep track of Goto's three criteria
     goto_criteria = 0
-    for n in xrange(1, reference_beats.shape[0]-1):
+    for n in range(1, reference_beats.shape[0]-1):
         # Get previous inner-reference-beat-interval
         previous_interval = 0.5*(reference_beats[n] - reference_beats[n-1])
         # Window start - in the middle of the current beat and the previous
@@ -465,7 +460,7 @@ def continuity(reference_beats,
         used_annotations = np.zeros(n_annotations)
         # Whether or not we are continuous at any given point
         beat_successes = np.zeros(n_annotations)
-        for m in xrange(estimated_beats.shape[0]):
+        for m in range(estimated_beats.shape[0]):
             # Is this beat correct?
             beat_success = 0
             # Get differences for this beat
@@ -637,7 +632,7 @@ def _get_entropy(reference_beats, estimated_beats, bins):
 
     """
     beat_error = np.zeros(estimated_beats.shape[0])
-    for n in xrange(estimated_beats.shape[0]):
+    for n in range(estimated_beats.shape[0]):
         # Get index of closest annotation to this beat
         beat_distances = estimated_beats[n] - reference_beats
         closest_beat = np.argmin(np.abs(beat_distances))

--- a/mir_eval/beat.py
+++ b/mir_eval/beat.py
@@ -53,6 +53,11 @@ import warnings
 # The maximum allowable beat time
 MAX_TIME = 30000.
 
+try:
+    xrange
+except NameError:
+    xrange = range
+
 
 def trim_beats(beats, min_beat_time=5.):
     """Removes beats before min_beat_time.  A common preprocessing step.

--- a/mir_eval/input_output.py
+++ b/mir_eval/input_output.py
@@ -9,6 +9,11 @@ import scipy.io.wavfile
 
 from . import util
 
+try:
+    xrange
+except NameError:
+    xrange = range
+
 
 def load_delimited(filename, converters, delimiter=r'\s+'):
     r"""Utility function for loading in data from an annotation file where columns

--- a/mir_eval/input_output.py
+++ b/mir_eval/input_output.py
@@ -9,11 +9,6 @@ import scipy.io.wavfile
 
 from . import util
 
-try:
-    xrange
-except NameError:
-    xrange = range
-
 
 def load_delimited(filename, converters, delimiter=r'\s+'):
     r"""Utility function for loading in data from an annotation file where columns
@@ -48,7 +43,7 @@ def load_delimited(filename, converters, delimiter=r'\s+'):
     """
     # Initialize list of empty lists
     n_columns = len(converters)
-    columns = tuple(list() for _ in xrange(n_columns))
+    columns = tuple(list() for _ in range(n_columns))
 
     # Create re object for splitting lines
     splitter = re.compile(delimiter)

--- a/mir_eval/pattern.py
+++ b/mir_eval/pattern.py
@@ -62,6 +62,11 @@ from . import util
 import warnings
 import collections
 
+try:
+    xrange
+except NameError:
+    xrange = range
+
 
 def _n_onset_midi(patterns):
     """Computes the number of onset_midi objects in a pattern

--- a/mir_eval/pattern.py
+++ b/mir_eval/pattern.py
@@ -62,11 +62,6 @@ from . import util
 import warnings
 import collections
 
-try:
-    xrange
-except NameError:
-    xrange = range
-
 
 def _n_onset_midi(patterns):
     """Computes the number of onset_midi objects in a pattern
@@ -498,8 +493,8 @@ def three_layer_FPR(reference_patterns, estimated_patterns):
         nP = len(ref_elements)      # Number of elements in reference
         nQ = len(est_elements)      # Number of elements in estimation
         F = np.zeros((nP, nQ))      # F-measure matrix for the given layer
-        for iP in xrange(nP):
-            for iQ in xrange(nQ):
+        for iP in range(nP):
+            for iQ in range(nQ):
                 if layer == 1:
                     func = compute_first_layer_PR
                 elif layer == 2:

--- a/mir_eval/segment.py
+++ b/mir_eval/segment.py
@@ -1018,8 +1018,12 @@ def nce(reference_intervals, reference_labels, estimated_intervals,
     # H(true | prediction) = sum_j P[estimated = j] *
     # sum_i P[true = i | estimated = j] log P[true = i | estimated = j]
     # entropy sums over axis=0, which is true labels
-    true_given_est = p_est.dot(scipy.stats.entropy(contingency, base=2))
-    pred_given_ref = p_ref.dot(scipy.stats.entropy(contingency.T, base=2))
+
+    # The following scipy.stats.entropy calls are equivalent to
+    # scipy.stats.entropy(contingency, base=2)
+    # However the `base` kwarg has only been introduced in scipy 0.14.0
+    true_given_est = p_est.dot(scipy.stats.entropy(contingency) / np.log(2))
+    pred_given_ref = p_ref.dot(scipy.stats.entropy(contingency.T) / np.log(2))
 
     score_under = 0.0
     if contingency.shape[0] > 1:

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -41,6 +41,11 @@ import itertools
 import warnings
 from . import util
 
+try:
+    xrange
+except NameError:
+    xrange = range
+
 
 # The maximum allowable number of sources (prevents insane computational load)
 MAX_SOURCES = 100

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -41,11 +41,6 @@ import itertools
 import warnings
 from . import util
 
-try:
-    xrange
-except NameError:
-    xrange = range
-
 
 # The maximum allowable number of sources (prevents insane computational load)
 MAX_SOURCES = 100
@@ -170,8 +165,8 @@ def bss_eval_sources(reference_sources, estimated_sources):
     sdr = np.empty((nsrc, nsrc))
     sir = np.empty((nsrc, nsrc))
     sar = np.empty((nsrc, nsrc))
-    for jest in xrange(nsrc):
-        for jtrue in xrange(nsrc):
+    for jest in range(nsrc):
+        for jtrue in range(nsrc):
             s_true, e_spat, e_interf, e_artif = \
                 _bss_decomp_mtifilt(reference_sources,
                                     estimated_sources[jest],
@@ -180,7 +175,7 @@ def bss_eval_sources(reference_sources, estimated_sources):
                 _bss_source_crit(s_true, e_spat, e_interf, e_artif)
 
     # select the best ordering
-    perms = list(itertools.permutations(xrange(nsrc)))
+    perms = list(itertools.permutations(range(nsrc)))
     mean_sir = np.empty(len(perms))
     dum = np.arange(nsrc)
     for (i, perm) in enumerate(perms):
@@ -256,8 +251,8 @@ def _project(reference_sources, estimated_source, flen):
     sef = scipy.fftpack.fft(estimated_source, n=n_fft)
     # inner products between delayed versions of reference_sources
     G = np.zeros((nsrc * flen, nsrc * flen))
-    for i in xrange(nsrc):
-        for j in xrange(nsrc):
+    for i in range(nsrc):
+        for j in range(nsrc):
             ssf = sf[i] * np.conj(sf[j])
             ssf = np.real(scipy.fftpack.ifft(ssf))
             ss = toeplitz(np.hstack((ssf[0], ssf[-1:-flen:-1])),
@@ -267,7 +262,7 @@ def _project(reference_sources, estimated_source, flen):
     # inner products between estimated_source and delayed versions of
     # reference_sources
     D = np.zeros(nsrc * flen)
-    for i in xrange(nsrc):
+    for i in range(nsrc):
         ssef = sf[i] * np.conj(sef)
         ssef = np.real(scipy.fftpack.ifft(ssef))
         D[i * flen: (i+1) * flen] = np.hstack((ssef[0], ssef[-1:-flen:-1]))
@@ -280,7 +275,7 @@ def _project(reference_sources, estimated_source, flen):
         C = np.linalg.lstsq(G, D)[0].reshape(flen, nsrc, order='F')
     # Filtering
     sproj = np.zeros(nsampl + flen - 1)
-    for i in xrange(nsrc):
+    for i in range(nsrc):
         sproj += fftconvolve(C[:, i], reference_sources[i])[:nsampl + flen - 1]
     return sproj
 

--- a/mir_eval/util.py
+++ b/mir_eval/util.py
@@ -7,11 +7,6 @@ import numpy as np
 import os
 import inspect
 
-try:
-    xrange
-except NameError:
-    xrange = range
-
 
 def index_labels(labels, case_sensitive=False):
     """Convert a list of string identifiers into numerical indices.
@@ -73,7 +68,7 @@ def generate_labels(items, prefix='__'):
         Synthetically generated labels
 
     """
-    return ['{}{}'.format(prefix, n) for n in xrange(len(items))]
+    return ['{}{}'.format(prefix, n) for n in range(len(items))]
 
 
 def intervals_to_samples(intervals, labels, offset=0, sample_size=0.1,

--- a/mir_eval/util.py
+++ b/mir_eval/util.py
@@ -7,6 +7,11 @@ import numpy as np
 import os
 import inspect
 
+try:
+    xrange
+except NameError:
+    xrange = range
+
 
 def index_labels(labels, case_sensitive=False):
     """Convert a list of string identifiers into numerical indices.
@@ -230,7 +235,7 @@ def boundaries_to_intervals(boundaries, labels=None):
     if not np.allclose(boundaries, np.unique(boundaries)):
         raise ValueError('Boundary times are not unique or not ascending.')
 
-    intervals = np.asarray(zip(boundaries[:-1], boundaries[1:]))
+    intervals = np.asarray(list(zip(boundaries[:-1], boundaries[1:])))
 
     if labels is None:
         interval_labels = None
@@ -715,7 +720,7 @@ def filter_kwargs(function, *args, **kwargs):
     function_args = inspect.getargspec(function).args
     # Construct a dict of those kwargs which appear in the function
     filtered_kwargs = {}
-    for kwarg, value in kwargs.items():
+    for kwarg, value in list(kwargs.items()):
         if kwarg in function_args:
             filtered_kwargs[kwarg] = value
     # Call the function with the supplied args and the filtered kwarg dict

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,8 @@ setup(
         'Development Status :: 5 - Production/Stable',
         "Intended Audience :: Developers",
         "Topic :: Multimedia :: Sound/Audio :: Analysis",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
     ],
     keywords='audio music mir dsp',
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,6 @@ setup(
     license='MIT',
     install_requires=[
         'numpy >= 1.7.0',
-        'scipy',
+        'scipy >= 0.9.0',
     ],
 )

--- a/tests/generate_data.py
+++ b/tests/generate_data.py
@@ -19,6 +19,7 @@ So, for example, if you'd like to generate data for onset and melody,run
     ./generate_data.py onset melody
 '''
 
+from __future__ import print_function
 import mir_eval
 import glob
 import json
@@ -66,7 +67,7 @@ if __name__ == '__main__':
                            'data/separation/{}*')
     # Get task keys from argv
     for task in sys.argv[1:]:
-        print 'Generating data for {}'.format(task)
+        print('Generating data for {}'.format(task))
         submodule, loader, data_glob = tasks[task]
         # Cycle through annotation file pairs
         for ref_file, est_file in zip(glob.glob(data_glob.format('ref')),

--- a/tests/generate_data.py
+++ b/tests/generate_data.py
@@ -52,19 +52,19 @@ if __name__ == '__main__':
     # that task will be generated.
     tasks = {}
     tasks['beat'] = (mir_eval.beat, mir_eval.io.load_events,
-                     'data/beat/{}*.txt')
+                     'tests/data/beat/{}*.txt')
     tasks['chord'] = (mir_eval.chord, mir_eval.io.load_labeled_intervals,
-                      'data/chord/{}*.lab')
+                      'tests/data/chord/{}*.lab')
     tasks['melody'] = (mir_eval.melody, mir_eval.io.load_time_series,
-                       'data/melody/{}*.txt')
+                       'tests/data/melody/{}*.txt')
     tasks['onset'] = (mir_eval.onset, mir_eval.io.load_events,
-                      'data/onset/{}*.txt')
+                      'tests/data/onset/{}*.txt')
     tasks['pattern'] = (mir_eval.pattern, mir_eval.io.load_patterns,
-                        'data/pattern/{}*.txt')
+                        'tests/data/pattern/{}*.txt')
     tasks['segment'] = (mir_eval.segment, mir_eval.io.load_labeled_intervals,
-                        'data/segment/{}*.lab')
+                        'tests/data/segment/{}*.lab')
     tasks['separation'] = (mir_eval.separation, load_separation_data,
-                           'data/separation/{}*')
+                           'tests/data/separation/{}*')
     # Get task keys from argv
     for task in sys.argv[1:]:
         print('Generating data for {}'.format(task))

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -12,9 +12,9 @@ import nose.tools
 A_TOL = 1e-12
 
 # Path to the fixture files
-REF_GLOB = 'data/beat/ref*.txt'
-EST_GLOB = 'data/beat/est*.txt'
-SCORES_GLOB = 'data/beat/output*.json'
+REF_GLOB = 'tests/data/beat/ref*.txt'
+EST_GLOB = 'tests/data/beat/est*.txt'
+SCORES_GLOB = 'tests/data/beat/output*.json'
 
 
 def test_trim_beats():

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -65,6 +65,8 @@ def test_beat_functions():
     est_files = sorted(glob.glob(EST_GLOB))
     sco_files = sorted(glob.glob(SCORES_GLOB))
 
+    assert len(ref_files) == len(est_files) == len(sco_files) > 0
+
     # Unit tests
     for metric in [mir_eval.beat.f_measure,
                    mir_eval.beat.cemgil,

--- a/tests/test_chord.py
+++ b/tests/test_chord.py
@@ -12,9 +12,9 @@ import json
 A_TOL = 1e-12
 
 # Path to the fixture files
-REF_GLOB = 'data/chord/ref*.lab'
-EST_GLOB = 'data/chord/est*.lab'
-SCORES_GLOB = 'data/chord/output*.json'
+REF_GLOB = 'tests/data/chord/ref*.lab'
+EST_GLOB = 'tests/data/chord/est*.lab'
+SCORES_GLOB = 'tests/data/chord/output*.json'
 
 
 def __check_valid(function, parameters, result):

--- a/tests/test_chord.py
+++ b/tests/test_chord.py
@@ -89,11 +89,11 @@ def test_join():
     # Arguments are root, quality, extensions, bass
     splits = [('F#', '', None, ''),
               ('F#', 'hdim7', None, ''),
-              ('F#', '', {'*b3', '4'}, ''),
+              ('F#', '', ['*b3', '4'], ''),
               ('F#', '', None, 'b7'),
-              ('F#', '', {'*b3', '4'}, 'b7'),
+              ('F#', '', ['*b3', '4'], 'b7'),
               ('F#', 'hdim7', None, 'b7'),
-              ('F#', 'hdim7', {'*b3', '4'}, 'b7')]
+              ('F#', 'hdim7', ['*b3', '4'], 'b7')]
     labels = ['F#', 'F#:hdim7', 'F#:(*b3,4)', 'F#/b7',
               'F#:(*b3,4)/b7', 'F#:hdim7/b7', 'F#:hdim7(*b3,4)/b7']
 

--- a/tests/test_chord.py
+++ b/tests/test_chord.py
@@ -432,6 +432,8 @@ def test_beat_functions():
     est_files = sorted(glob.glob(EST_GLOB))
     sco_files = sorted(glob.glob(SCORES_GLOB))
 
+    assert len(ref_files) == len(est_files) == len(sco_files) > 0
+
     # Regression tests
     for ref_f, est_f, sco_f in zip(ref_files, est_files, sco_files):
         with open(sco_f, 'r') as f:

--- a/tests/test_melody.py
+++ b/tests/test_melody.py
@@ -13,9 +13,9 @@ import warnings
 A_TOL = 1e-12
 
 # Path to the fixture files
-REF_GLOB = 'data/melody/ref*.txt'
-EST_GLOB = 'data/melody/est*.txt'
-SCORES_GLOB = 'data/melody/output*.json'
+REF_GLOB = 'tests/data/melody/ref*.txt'
+EST_GLOB = 'tests/data/melody/est*.txt'
+SCORES_GLOB = 'tests/data/melody/output*.json'
 
 
 def test_hz2cents():

--- a/tests/test_melody.py
+++ b/tests/test_melody.py
@@ -152,6 +152,8 @@ def test_melody_functions():
     est_files = sorted(glob.glob(EST_GLOB))
     sco_files = sorted(glob.glob(SCORES_GLOB))
 
+    assert len(ref_files) == len(est_files) == len(sco_files) > 0
+
     # Unit tests
     for metric in [mir_eval.melody.voicing_measures,
                    mir_eval.melody.raw_pitch_accuracy,

--- a/tests/test_onset.py
+++ b/tests/test_onset.py
@@ -12,9 +12,9 @@ import nose.tools
 A_TOL = 1e-12
 
 # Path to the fixture files
-REF_GLOB = 'data/onset/ref*.txt'
-EST_GLOB = 'data/onset/est*.txt'
-SCORES_GLOB = 'data/onset/output*.json'
+REF_GLOB = 'tests/data/onset/ref*.txt'
+EST_GLOB = 'tests/data/onset/est*.txt'
+SCORES_GLOB = 'tests/data/onset/output*.json'
 
 
 def __unit_test_onset_function(metric):

--- a/tests/test_onset.py
+++ b/tests/test_onset.py
@@ -57,6 +57,8 @@ def test_onset_functions():
     est_files = sorted(glob.glob(EST_GLOB))
     sco_files = sorted(glob.glob(SCORES_GLOB))
 
+    assert len(ref_files) == len(est_files) == len(sco_files) > 0
+
     # Unit tests
     for metric in [mir_eval.onset.f_measure]:
         yield (__unit_test_onset_function, metric)

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -12,9 +12,9 @@ import nose.tools
 A_TOL = 1e-12
 
 # Path to the fixture files
-REF_GLOB = 'data/pattern/ref*.txt'
-EST_GLOB = 'data/pattern/est*.txt'
-SCORES_GLOB = 'data/pattern/output*.json'
+REF_GLOB = 'tests/data/pattern/ref*.txt'
+EST_GLOB = 'tests/data/pattern/est*.txt'
+SCORES_GLOB = 'tests/data/pattern/output*.json'
 
 
 def __unit_test_pattern_function(metric):

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -54,6 +54,8 @@ def test_pattern_functions():
     est_files = sorted(glob.glob(EST_GLOB))
     sco_files = sorted(glob.glob(SCORES_GLOB))
 
+    assert len(ref_files) == len(est_files) == len(sco_files) > 0
+
     # Unit tests
     for metric in [mir_eval.pattern.standard_FPR,
                    mir_eval.pattern.establishment_FPR,

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -12,9 +12,9 @@ import nose.tools
 A_TOL = 1e-12
 
 # Path to the fixture files
-REF_GLOB    = 'data/segment/ref*.lab'
-EST_GLOB    = 'data/segment/est*.lab'
-SCORES_GLOB  = 'data/segment/output*.json'
+REF_GLOB    = 'tests/data/segment/ref*.lab'
+EST_GLOB    = 'tests/data/segment/est*.lab'
+SCORES_GLOB  = 'tests/data/segment/output*.json'
 
 
 def __unit_test_boundary_function(metric):

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -116,6 +116,8 @@ def test_segment_functions():
     est_files = sorted(glob.glob(EST_GLOB))
     sco_files = sorted(glob.glob(SCORES_GLOB))
 
+    assert len(ref_files) == len(est_files) == len(sco_files) > 0
+
     # Unit tests for boundary
     for metric in [mir_eval.segment.detection,
                    mir_eval.segment.deviation]:

--- a/tests/test_separation.py
+++ b/tests/test_separation.py
@@ -16,9 +16,9 @@ import warnings
 
 A_TOL = 1e-12
 
-REF_GLOB = 'data/separation/ref*'
-EST_GLOB = 'data/separation/est*'
-SCORES_GLOB = 'data/separation/output*.json'
+REF_GLOB = 'tests/data/separation/ref*'
+EST_GLOB = 'tests/data/separation/est*'
+SCORES_GLOB = 'tests/data/separation/output*.json'
 
 
 def __load_and_stack_wavs(directory):

--- a/tests/test_separation.py
+++ b/tests/test_separation.py
@@ -78,6 +78,8 @@ def test_separation_functions():
     est_files = sorted(glob.glob(EST_GLOB))
     sco_files = sorted(glob.glob(SCORES_GLOB))
 
+    assert len(ref_files) == len(est_files) == len(sco_files) > 0
+
     # Unit tests
     for metric in [mir_eval.separation.bss_eval_sources]:
         yield (__unit_test_separation_function, metric)


### PR DESCRIPTION
This PR comprises three things mainly:

Since the travis branch was depending on the other two changes, too I opted to merge them into one PR.

### Python 3.

You mentioned in the original ticket that you don't support Python 3 yet... So I fixed that for you :-)

Nothing fancy, mainly `print` and `xargs` were acting up.

The only bigger thing was in `evaluators/eval_utilities.py`. In Python 3 `dict.items()` was always an iterable, while in Python 2 you had to explicitly call `dict.iteritems()`. There is a function `iteritems` in `future.utils` that implements it cross-version.

### Failing Tests

There were two issues with the tests:

Running `nosetests` from the root directory of the project failed as the scripts could not find the testdata. Prepending `tests/` to their path fixed the issue.

Also, there was an error only showing up intermittently: 

    ======================================================================
    FAIL: test_chord.test_join(<function join at 0x7f9dcc65ec80>, ('F#', '', {'4', '*b3'}, 'b7'), 'F#:(*b3,4)/b7')
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/usr/lib/python3.4/site-packages/nose/case.py", line 198, in runTest
        self.test(*self.arg)
      File "/home/nils/Arbeit/mireval3/mir_eval/tests/test_chord.py", line 22, in __check_valid
        assert function(*parameters) == result
    AssertionError

This had to do with the testdata being wrapped in `dict`s where they should've been in `lists` as `dict`s are not ordered. In some of the testruns the order of the arguments were reversed and the string comparison failed.

### Travis CI

It implements a working Travis CI file (see <https://travis-ci.org/nils-werner/mir_eval>).

Basically it tests on all Python versions, minus the ones not supported by some of the dependencies:

 - Python < 3.3 does not work with numpydoc (and I am building docs, too)
 - Python 3.4 does not have scipy wheels yet

PIP wheels are a form of precompiled dependencies. Compiling NumPy and SciPy from source takes quite a while and is really annoying when you just want to run some tests. Hence I am currently using the wheels made by the AstroPy folks. Unfortunately there are no wheels for Py 3.4 yet.

Also interestingly AstroPy has moved to [using Miniconda as their Python environment during testing](https://github.com/astropy/astropy/blob/master/.continuous-integration/travis/setup_dependencies_common.sh) for exacly these annoying NumPy+SciPy issues. Maybe that's a solution for you guys, too.