### PR TITLE
Remove call to inspect.getargspec, use 3.5 for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ notifications:
 python:
     - "2.7"
     - "3.4"
+    - "3.5"
 
 before_install:
     - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then

--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,8 @@ If you're looking for the mir_eval web service, which you can use to run mir_eva
 Dependencies:
 
 * `Scipy/Numpy <http://www.scipy.org/>`_
+* future
+* six
 
 If you use mir_eval in a research project, please cite the following paper:
 

--- a/mir_eval/util.py
+++ b/mir_eval/util.py
@@ -5,7 +5,7 @@ submodules, such as preprocessing, validation, and common computations.
 
 import numpy as np
 import os
-import inspect
+import six
 
 
 def index_labels(labels, case_sensitive=False):
@@ -280,7 +280,7 @@ def adjust_intervals(intervals,
     Returns
     -------
     new_intervals : np.ndarray
-        Intervals spanning [t_min, t_max]    
+        Intervals spanning [t_min, t_max]
     new_labels : list
         List of labels for new_labels
 
@@ -441,7 +441,7 @@ def intersect_files(flist1, flist2):
         Parameters
         ----------
         abs_path :
-            
+
 
         Returns
         -------
@@ -509,13 +509,13 @@ def _bipartite_match(graph):
     """Find maximum cardinality matching of a bipartite graph (U,V,E).
     The input format is a dictionary mapping members of U to a list
     of their neighbors in V.
-    
+
     The output is a dict M mapping members of V to their matches in U.
 
     Parameters
     ----------
     graph :
-        
+
 
     Returns
     -------
@@ -580,7 +580,7 @@ def _bipartite_match(graph):
             Parameters
             ----------
             v :
-                
+
 
             Returns
             -------
@@ -712,7 +712,8 @@ def filter_kwargs(function, *args, **kwargs):
 
     """
     # Get the list of function arguments
-    function_args = inspect.getargspec(function).args
+    func_code = six.get_function_code(function)
+    function_args = func_code.co_varnames[:func_code.co_argcount]
     # Construct a dict of those kwargs which appear in the function
     filtered_kwargs = {}
     for kwarg, value in list(kwargs.items()):

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,7 @@ setup(
     install_requires=[
         'numpy >= 1.7.0',
         'scipy >= 0.9.0',
+        'future',
+        'six'
     ],
 )


### PR DESCRIPTION
Resolves #133.  Replaces the call in `util.filter_kwargs` to `inspect.getargspec` with a two-line equivalent, and ups the testing Python3 version to 3.5.