### PR TITLE
Remove special case from beat.continuity

### DIFF
--- a/mir_eval/beat.py
+++ b/mir_eval/beat.py
@@ -493,14 +493,8 @@ def continuity(reference_beats,
                 if m == 0 or nearest == 0:
                     # How far is the estimated beat from the reference beat,
                     # relative to the inter-annotation-interval?
-                    if nearest + 1 < reference_beats.shape[0]:
-                        reference_interval = (reference_beats[nearest + 1] -
-                                              reference_beats[nearest])
-                    else:
-                        # Special case when nearest + 1 is too large - use the
-                        # previous interval instead
-                        reference_interval = (reference_beats[nearest] -
-                                              reference_beats[nearest - 1])
+                    reference_interval = (reference_beats[nearest + 1] -
+                                          reference_beats[nearest])
                     # Handle this special case when beats are not unique
                     if reference_interval == 0:
                         if min_difference == 0:


### PR DESCRIPTION
Now that beat.continuity returns early when there is one estimated or reference beat, this logic is no longer reachable because `nearest = 0` and` nearest + 1 = 1` is never `>= reference_beats.shape[0]`.