### PR TITLE
Rounding up the intervals before converting them

### DIFF
--- a/mir_eval/util.py
+++ b/mir_eval/util.py
@@ -203,8 +203,7 @@ def intervals_to_boundaries(intervals):
 
     """
 
-    return np.concatenate((intervals.flatten()[::2], [intervals[-1, -1]]),
-                          axis=0)
+    return np.unique(np.ravel(np.round(intervals, decimals=5)))
 
 
 def boundaries_to_intervals(boundaries, labels=None):

--- a/mir_eval/util.py
+++ b/mir_eval/util.py
@@ -188,13 +188,15 @@ def f_measure(precision, recall, beta=1.0):
     return (1 + beta**2)*precision*recall/((beta**2)*precision + recall)
 
 
-def intervals_to_boundaries(intervals):
+def intervals_to_boundaries(intervals, q=5):
     """Convert interval times into boundaries.
 
     Parameters
     ----------
     intervals : np.ndarray, shape=(n_events, 2)
         Array of interval start and end-times
+    q : int
+        Number of decimals to round to.
 
     Returns
     -------
@@ -203,7 +205,7 @@ def intervals_to_boundaries(intervals):
 
     """
 
-    return np.unique(np.ravel(np.round(intervals, decimals=5)))
+    return np.unique(np.ravel(np.round(intervals, decimals=q)))
 
 
 def boundaries_to_intervals(boundaries, labels=None):


### PR DESCRIPTION
This comes from #144, where undefined behavior occurs when using `np.unique` with large float numbers. This should fix it.