### PR TITLE
Remove unreachable weighted_accuracy case

### DIFF
--- a/mir_eval/chord.py
+++ b/mir_eval/chord.py
@@ -692,9 +692,6 @@ def weighted_accuracy(comparisons, weights):
     if np.sum(weights) == 0:
         warnings.warn('No nonzero weights, returning 0')
         return 0
-    # Return 0 when no labels are given
-    if len(comparisons) == 0:
-        return 0
     # Find all comparison scores which are valid
     valid_idx = (comparisons >= 0)
     # If no comparable chords were provided, warn and return 0


### PR DESCRIPTION
cc @ejhumphrey 

This case is not reachable.  In order for `len(comparisons) == 0`, we'd need to have `len(weights) == 0`, because otherwise a `ValueError` would be raised because they are of different length.  But, if `len(weights) == 0` then `np.sum(weights) == 0` so the function returns early at line 694.