### PR TITLE
Remove chord.rotate_bass_to_root function

### DIFF
--- a/mir_eval/chord.py
+++ b/mir_eval/chord.py
@@ -596,25 +596,6 @@ def rotate_bitmaps_to_roots(bitmaps, roots):
     return np.asarray(abs_bitmaps)
 
 
-def rotate_bass_to_root(bass, chord_root):
-    """Rotate a relative bass interval to its asbolute pitch class.
-
-    Parameters
-    ----------
-    bass : int
-        Relative bass interval.
-    chord_root : int
-        Absolute root pitch class.
-
-    Returns
-    -------
-    bass : int
-        Pitch class of the bass interval.
-
-    """
-    return (bass + chord_root) % 12
-
-
 # --- Comparison Routines ---
 def validate(reference_labels, estimated_labels):
     """Checks that the input annotations to a comparison function look like


### PR DESCRIPTION
cc @ejhumphrey (we talked about this last night)

It wasn't being called anywhere in mir_eval.chord, or in any of the tests for evaluators.  It was added in case it was needed for future metrics. If and when it's something that is needed for future metrics, we can add it back in.