### PR TITLE
Bugfix: Typo in variable name

### DIFF
--- a/mir_eval/melody.py
+++ b/mir_eval/melody.py
@@ -214,11 +214,11 @@ def resample_melody_series(times, frequencies, voicing,
 
     """
     # Warn when the delta between the original times is not constant,
-    # unless times[0] == 0. and frequencies[0] == frequences[1] (see logic at
-    # the begnning of to_cent_voicing)
+    # unless times[0] == 0. and frequencies[0] == frequencies[1] (see logic at
+    # the beginning of to_cent_voicing)
     if not (np.allclose(np.diff(times), np.diff(times).mean()) or
             (np.allclose(np.diff(times[1:]), np.diff(times[1:]).mean()) and
-             frequences[0] == frequencies[1])):
+             frequencies[0] == frequencies[1])):
         warnings.warn(
             "Non-uniform timescale passed to resample_melody_series.  Pitch "
             "will be linearly interpolated, which will result in undesirable "


### PR DESCRIPTION
Can be reconstructed by setting ref to est.

ref_time = melodia_time
ref_freq = melodia_freq

est_time = ref_time
est_freq = est_time

melody_scores = mir_eval.melody.evaluate(ref_time, ref_freq,
                                                                      est_time, est_freq)

Error was then:
NameError: global name 'frequences' is not defined