### PR TITLE
Allow pattern.standard_FPR to take len-1 patterns

### DIFF
--- a/mir_eval/pattern.py
+++ b/mir_eval/pattern.py
@@ -229,7 +229,8 @@ def standard_FPR(reference_patterns, estimated_patterns, tol=1e-5):
                 continue
 
             # Check transposition given a certain tolerance
-            if np.max(np.abs(np.diff(P - Q, axis=0))) < tol:
+            if (len(P) == len(Q) == 1 or
+                    np.max(np.abs(np.diff(P - Q, axis=0))) < tol):
                 k += 1
                 break
 


### PR DESCRIPTION
When `reference_patterns` or `estimated_patterns` were both of length 1, then np.diff(P - Q, axis=0) would return an array of shape `(0, 2)` which would cause a `ValueError` from `np.max`.  This test was basically just that the change in semitones in the reference and estimated patterns was the same.  When there's only one note in the pattern, the change in semitones is the same, so we just add the one-note case as a special case.  Will resolve #122.  @urinieto would be great to get your input/go-ahead on this.