### PR TITLE
fixed value checking for frame_size in t-measures

### DIFF
--- a/mir_eval/hierarchy.py
+++ b/mir_eval/hierarchy.py
@@ -332,16 +332,16 @@ def tmeasure(reference_intervals_hier, estimated_intervals_hier,
     '''
 
     # Compute the number of frames in the window
+    if frame_size <= 0:
+        raise ValueError('frame_size ({:.2f}) must be a positive '
+                         'number.'.format(frame_size))
+
     if window is None:
         window_frames = None
     else:
         if frame_size > window:
             raise ValueError('frame_size ({:.2f}) cannot exceed '
                              'window ({:.2f})'.format(frame_size, window))
-
-        if frame_size <= 0:
-            raise ValueError('frame_size ({:.2f}) must be a positive '
-                             'number.'.format(frame_size))
 
         window_frames = int(_round(window, frame_size) / frame_size)
 

--- a/tests/test_hierarchy.py
+++ b/tests/test_hierarchy.py
@@ -109,9 +109,11 @@ def test_tmeasure_fail_frame_size():
                                     window=window,
                                     frame_size=frame_size)
 
-    for window in [15, 30]:
-        for frame_size in [-1, 0, 2 * window]:
+    for window in [None, 15, 30]:
+        for frame_size in [-1, 0]:
             yield __test, window, frame_size
+        if window is not None:
+            yield __test, window, 2 * window
 
 
 def test_tmeasure_regression():


### PR DESCRIPTION
I ran into a minor bug that can occur if you call `tmeasures` with `window=None` and an invalid `frame_size`.

This PR fixes the bug.