### PR TITLE
added .coveragerc to fix recent break in coveralls api

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[report]
+omit =
+    */python?.?/*
+    */site-packages/nose/*


### PR DESCRIPTION
Coveralls recently (within the last couple of months) changed something in either their api or the python package, such that tests do not get reported if there's no `.coveragerc` file.  You may have noticed that coverage reports have been missing.

This PR adds a simple .coveragerc so that reports work again.