### PR TITLE
Add tempo to docs (and minor fix(es))

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -169,6 +169,14 @@ The following subsections document each submodule.
    :show-inheritance:
    :member-order: bysource
 
+:mod:`mir_eval.tempo`
+--------------------------
+.. automodule:: mir_eval.tempo
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :member-order: bysource
+
 :mod:`mir_eval.transcription`
 -----------------------------
 .. automodule:: mir_eval.transcription

--- a/mir_eval/tempo.py
+++ b/mir_eval/tempo.py
@@ -16,8 +16,8 @@ The weighting value from the reference must be a float in the range [0, 1].
 
 Metrics
 -------
-:func:`mir_eval.tempo.detection`
-    Relative error, hits, and weighted precision of tempo estimation.
+* :func:`mir_eval.tempo.detection`: Relative error, hits, and weighted
+  precision of tempo estimation.
 
 '''
 

--- a/mir_eval/tempo.py
+++ b/mir_eval/tempo.py
@@ -24,7 +24,6 @@ Metrics
 import numpy as np
 import collections
 from . import util
-import warnings
 
 
 def validate_tempi(tempi):


### PR DESCRIPTION
The tempo submodule never got added to index.rst.  There was also some minor formatting inconsistencies in the submodule-level docstring.  Finally, there was an unused `warnings` import; may as well take care of that here.  @bmcfee any objections?