### PR TITLE
Avoiding framewise silence issues

### DIFF
--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -109,7 +109,7 @@ def validate(reference_sources, estimated_sources):
 
 
 def _any_source_silent(sources):
-    """Returns true if the parameter sources has any silent first dimensions."""
+    """Returns true if the parameter sources has any silent first dimensions"""
     return (np.any(np.all(np.sum(sources,
                                  axis=tuple(range(2, sources.ndim))) == 0,
                           axis=1)))

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -324,11 +324,32 @@ def bss_eval_sources_framewise(reference_sources, estimated_sources,
     # k iterates across all the windows
     for k in range(nwin):
         win_slice = slice(k * hop, k * hop + window)
-        sdr[:, k], sir[:, k], sar[:, k], perm[:, k] = bss_eval_sources(
-            reference_sources[:, win_slice],
-            estimated_sources[:, win_slice],
-            compute_permutation
-        )
+        ref_slice = reference_sources[:, win_slice]
+        est_slice = estimated_sources[:, win_slice]
+        # check for a silent frame
+        if not (np.any(np.all(np.sum(ref_slice,
+                                     axis=tuple(range(2,
+                                                      ref_slice.ndim))) == 0,
+                              axis=1))) \
+                and not (np.any(np.all(np.sum(est_slice,
+                                              axis=tuple(
+                                                    range(
+                                                        2,
+                                                        est_slice.ndim
+                                                    )
+                                                )) == 0,
+                                axis=1))):
+            sdr[:, k], sir[:, k], sar[:, k], perm[:, k] = bss_eval_sources(
+                ref_slice,
+                est_slice,
+                compute_permutation
+            )
+        else:
+            # if we have a silent frame set results as np.nan
+            sdr[:, k] = np.nan
+            sir[:, k] = np.nan
+            sar[:, k] = np.nan
+            perm[:, k] = np.nan
 
     return sdr, sir, sar, perm
 
@@ -568,12 +589,34 @@ def bss_eval_images_framewise(reference_sources, estimated_sources,
     # k iterates across all the windows
     for k in range(nwin):
         win_slice = slice(k * hop, k * hop + window)
-        sdr[:, k], isr[:, k], sir[:, k], sar[:, k], perm[:, k] = \
-            bss_eval_images(
-                reference_sources[:, win_slice, :],
-                estimated_sources[:, win_slice, :],
-                compute_permutation
-            )
+        ref_slice = reference_sources[:, win_slice, :]
+        est_slice = estimated_sources[:, win_slice, :]
+        # check for a silent frame
+        if not (np.any(np.all(np.sum(ref_slice,
+                                     axis=tuple(range(2,
+                                                      ref_slice.ndim))) == 0,
+                              axis=1))) \
+                and not (np.any(np.all(np.sum(est_slice,
+                                              axis=tuple(
+                                                    range(
+                                                        2,
+                                                        est_slice.ndim
+                                                    )
+                                                )) == 0,
+                                axis=1))):
+            sdr[:, k], isr[:, k], sir[:, k], sar[:, k], perm[:, k] = \
+                bss_eval_images(
+                    ref_slice,
+                    est_slice,
+                    compute_permutation
+                )
+        else:
+            # if we have a silent frame set results as np.nan
+            sdr[:, k] = np.nan
+            isr[:, k] = np.nan
+            sir[:, k] = np.nan
+            sar[:, k] = np.nan
+            perm[:, k] = np.nan
 
     return sdr, isr, sir, sar, perm
 

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -337,10 +337,7 @@ def bss_eval_sources_framewise(reference_sources, estimated_sources,
             )
         else:
             # if we have a silent frame set results as np.nan
-            sdr[:, k] = np.nan
-            sir[:, k] = np.nan
-            sar[:, k] = np.nan
-            perm[:, k] = np.nan
+            sdr[:, k] = sir[:, k] = sar[:, k] = perm[:, k] = np.nan
 
     return sdr, sir, sar, perm
 
@@ -593,11 +590,7 @@ def bss_eval_images_framewise(reference_sources, estimated_sources,
                 )
         else:
             # if we have a silent frame set results as np.nan
-            sdr[:, k] = np.nan
-            isr[:, k] = np.nan
-            sir[:, k] = np.nan
-            sar[:, k] = np.nan
-            perm[:, k] = np.nan
+            sdr[:, k] = sir[:, k] = sar[:, k] = perm[:, k] = np.nan
 
     return sdr, isr, sir, sar, perm
 

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -111,7 +111,7 @@ def validate(reference_sources, estimated_sources):
 def _any_source_silent(sources):
     """Returns true if the parameter sources has any silent first dimensions"""
     return np.any(np.all(np.sum(
-        sources, axis=np.arange(2, sources.ndim)) == 0, axis=1))
+        sources, axis=tuple(range(2, sources.ndim))) == 0, axis=1))
 
 
 def bss_eval_sources(reference_sources, estimated_sources,
@@ -330,9 +330,7 @@ def bss_eval_sources_framewise(reference_sources, estimated_sources,
         if (not _any_source_silent(ref_slice) and
                 not _any_source_silent(est_slice)):
             sdr[:, k], sir[:, k], sar[:, k], perm[:, k] = bss_eval_sources(
-                ref_slice,
-                est_slice,
-                compute_permutation
+                ref_slice, est_slice, compute_permutation
             )
         else:
             # if we have a silent frame set results as np.nan
@@ -583,9 +581,7 @@ def bss_eval_images_framewise(reference_sources, estimated_sources,
                 not _any_source_silent(est_slice)):
             sdr[:, k], isr[:, k], sir[:, k], sar[:, k], perm[:, k] = \
                 bss_eval_images(
-                    ref_slice,
-                    est_slice,
-                    compute_permutation
+                    ref_slice, est_slice, compute_permutation
                 )
         else:
             # if we have a silent frame set results as np.nan

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -77,10 +77,7 @@ def validate(reference_sources, estimated_sources):
         warnings.warn("reference_sources is empty, should be of size "
                       "(nsrc, nsample).  sdr, sir, sar, and perm will all "
                       "be empty np.ndarrays")
-    elif (np.any(np.all(np.sum(reference_sources,
-                               axis=tuple(range(2,
-                                                reference_sources.ndim))) == 0,
-                        axis=1))):
+    elif _any_source_silent(reference_sources):
         raise ValueError('All the reference sources should be non-silent (not '
                          'all-zeros), but at least one of the reference '
                          'sources is all 0s, which introduces ambiguity to the'
@@ -91,10 +88,7 @@ def validate(reference_sources, estimated_sources):
         warnings.warn("estimated_sources is empty, should be of size "
                       "(nsrc, nsample).  sdr, sir, sar, and perm will all "
                       "be empty np.ndarrays")
-    elif (np.any(np.all(np.sum(estimated_sources,
-                               axis=tuple(range(2,
-                                                estimated_sources.ndim))) == 0,
-                        axis=1))):
+    elif _any_source_silent(estimated_sources):
         raise ValueError('All the estimated sources should be non-silent (not '
                          'all-zeros), but at least one of the estimated '
                          'sources is all 0s. Since we require each reference '
@@ -112,6 +106,13 @@ def validate(reference_sources, estimated_sources):
                          'larger value.'.format(reference_sources.shape[0],
                                                 estimated_sources.shape[0],
                                                 MAX_SOURCES))
+
+
+def _any_source_silent(sources):
+    """Returns true if the parameter sources has any silent first dimensions."""
+    return (np.any(np.all(np.sum(sources,
+                                 axis=tuple(range(2, sources.ndim))) == 0,
+                          axis=1)))
 
 
 def bss_eval_sources(reference_sources, estimated_sources,
@@ -327,18 +328,8 @@ def bss_eval_sources_framewise(reference_sources, estimated_sources,
         ref_slice = reference_sources[:, win_slice]
         est_slice = estimated_sources[:, win_slice]
         # check for a silent frame
-        if not (np.any(np.all(np.sum(ref_slice,
-                                     axis=tuple(range(2,
-                                                      ref_slice.ndim))) == 0,
-                              axis=1))) \
-                and not (np.any(np.all(np.sum(est_slice,
-                                              axis=tuple(
-                                                    range(
-                                                        2,
-                                                        est_slice.ndim
-                                                    )
-                                                )) == 0,
-                                axis=1))):
+        if not _any_source_silent(ref_slice) \
+                and not _any_source_silent(est_slice):
             sdr[:, k], sir[:, k], sar[:, k], perm[:, k] = bss_eval_sources(
                 ref_slice,
                 est_slice,
@@ -592,18 +583,8 @@ def bss_eval_images_framewise(reference_sources, estimated_sources,
         ref_slice = reference_sources[:, win_slice, :]
         est_slice = estimated_sources[:, win_slice, :]
         # check for a silent frame
-        if not (np.any(np.all(np.sum(ref_slice,
-                                     axis=tuple(range(2,
-                                                      ref_slice.ndim))) == 0,
-                              axis=1))) \
-                and not (np.any(np.all(np.sum(est_slice,
-                                              axis=tuple(
-                                                    range(
-                                                        2,
-                                                        est_slice.ndim
-                                                    )
-                                                )) == 0,
-                                axis=1))):
+        if not _any_source_silent(ref_slice) \
+                and not _any_source_silent(est_slice):
             sdr[:, k], isr[:, k], sir[:, k], sar[:, k], perm[:, k] = \
                 bss_eval_images(
                     ref_slice,

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -110,9 +110,8 @@ def validate(reference_sources, estimated_sources):
 
 def _any_source_silent(sources):
     """Returns true if the parameter sources has any silent first dimensions"""
-    return (np.any(np.all(np.sum(sources,
-                                 axis=tuple(range(2, sources.ndim))) == 0,
-                          axis=1)))
+    return np.any(np.all(np.sum(
+        sources, axis=np.arange(2, sources.ndim)) == 0, axis=1))
 
 
 def bss_eval_sources(reference_sources, estimated_sources,
@@ -328,8 +327,8 @@ def bss_eval_sources_framewise(reference_sources, estimated_sources,
         ref_slice = reference_sources[:, win_slice]
         est_slice = estimated_sources[:, win_slice]
         # check for a silent frame
-        if not _any_source_silent(ref_slice) \
-                and not _any_source_silent(est_slice):
+        if (not _any_source_silent(ref_slice) and
+                not _any_source_silent(est_slice)):
             sdr[:, k], sir[:, k], sar[:, k], perm[:, k] = bss_eval_sources(
                 ref_slice,
                 est_slice,
@@ -580,8 +579,8 @@ def bss_eval_images_framewise(reference_sources, estimated_sources,
         ref_slice = reference_sources[:, win_slice, :]
         est_slice = estimated_sources[:, win_slice, :]
         # check for a silent frame
-        if not _any_source_silent(ref_slice) \
-                and not _any_source_silent(est_slice):
+        if (not _any_source_silent(ref_slice) and
+                not _any_source_silent(est_slice)):
             sdr[:, k], isr[:, k], sir[:, k], sar[:, k], perm[:, k] = \
                 bss_eval_images(
                     ref_slice,


### PR DESCRIPTION
## Frame Silence Detection
This is to solve issue #213. A silent frame is detected by using the same check from validation before attempting to evaluate the function on the frame. This allows the silence of either the reference slice or estimate slice to be determined and then the results set as np.nan (decided as the best approach in #213).

## Unit Testing
Unit testing has been added and tests silence for both reference and estimate sources. No regression testing is required, as no values are determined. Fully silent sources will still fail the framewise evaluation since `validate` is called at the beginning of the framewise function.

#### The `if` statement
The style of the `if` statement is pretty horrid ([have a look at it here](https://github.com/faroit/mir_eval/blob/8c0ef33e1236b2661aa360ce887795974b5213b3/mir_eval/separation.py#L330)), but it passes pep8 checks for me. If anyone has advice on cleaning it up and make it easier to understand, that would be great!

**As always, all feedback is welcome!**