### PR TITLE
switched chord label validation to regexp method

### DIFF
--- a/mir_eval/chord.py
+++ b/mir_eval/chord.py
@@ -91,6 +91,8 @@ import numpy as np
 import warnings
 import collections
 
+import re
+
 from mir_eval import util
 
 BITMAP_LENGTH = 12
@@ -326,19 +328,17 @@ def validate_chord_label(chord_label):
         Chord label to validate.
 
     """
-    # Test for single special characters
-    for one_char in [':', '/', '(', ')']:
-        if chord_label.count(one_char) > 1:
-            raise InvalidChordException(
-                "Chord label may only contain one '%s'. "
-                "Received: '%s'" % (one_char, chord_label))
 
-    # Test for closed parens
-    parens = [paren in chord_label for paren in ['(', ')']]
-    if any(parens) and not all(parens):
-        raise InvalidChordException(
-            "Chord label must have closed parentheses. "
-            "Received: '%s'" % chord_label)
+    # This monster regexp is pulled from the JAMS chord namespace,
+    # which is in turn derived from the context-free grammar of
+    # Harte et al., 2005.
+
+    pattern = re.compile(r'''^((N|X)|(([A-G](b*|#*))((:(maj|min|dim|aug|1|5|sus2|sus4|maj6|min6|7|maj7|min7|dim7|hdim7|minmaj7|aug7|9|maj9|min9|11|maj11|min11|13|maj13|min13)(\((\*?((b*|#*)([1-9]|1[0-3]?))(,\*?((b*|#*)([1-9]|1[0-3]?)))*)\))?)|(:\((\*?((b*|#*)([1-9]|1[0-3]?))(,\*?((b*|#*)([1-9]|1[0-3]?)))*)\)))?((/((b*|#*)([1-9]|1[0-3]?)))?)?))$''')  # nopep8
+
+    if not pattern.match(chord_label):
+        raise InvalidChordException('Invalid chord label: '
+                                    '{}'.format(chord_label))
+    pass
 
 
 def split(chord_label, reduce_extended_chords=False):

--- a/tests/test_chord.py
+++ b/tests/test_chord.py
@@ -65,7 +65,7 @@ def test_validate_chord_label():
         yield (mir_eval.chord.validate_chord_label, chord_label)
 
     invalid_labels = ["C::maj", "C//5", "C((4)", "C5))",
-                      "C:maj(*3/3", "Cmaj*3/3)"]
+                      "C:maj(*3/3", "Cmaj*3/3)", 'asdf']
 
     for chord_label in invalid_labels:
         yield (__check_exception, mir_eval.chord.validate_chord_label,


### PR DESCRIPTION
This fixes #217 by using a regexp to parse chords, rather than explicit case splitting.

The regexp is ported over from JAMS, where it has already been thoroughly tested.  I added an extra test case 'asdf' that was mentioned in the #217 thread as previously passing.

Because the regexp is such a monster, I disabled the pep8 length check for the corresponding line.