### PR TITLE
fix #248, support gaps in labeled interval interpolation

### DIFF
--- a/mir_eval/util.py
+++ b/mir_eval/util.py
@@ -145,7 +145,8 @@ def interpolate_intervals(intervals, labels, time_points, fill_value=None):
         The annotation for each interval
 
     time_points : array_like, shape=(m,)
-        Points in time to assign labels.  These must be in ascending order.
+        Points in time to assign labels.  These must be in
+        non-decreasing order.
 
     fill_value : type(labels[0])
         Object to use for the label with out-of-range time points.
@@ -156,7 +157,17 @@ def interpolate_intervals(intervals, labels, time_points, fill_value=None):
     aligned_labels : list
         Labels corresponding to the given time points.
 
+    Raises
+    ------
+    ValueError
+        If `time_points` is not in non-decreasing order.
     """
+
+    # Verify that time_points is sorted
+    time_points = np.asarray(time_points)
+
+    if np.any(time_points[1:] < time_points[:-1]):
+        raise ValueError('time_points must be in non-decreasing order')
 
     aligned_labels = [fill_value] * len(time_points)
 

--- a/mir_eval/util.py
+++ b/mir_eval/util.py
@@ -3,7 +3,6 @@ This submodule collects useful functionality required across the task
 submodules, such as preprocessing, validation, and common computations.
 '''
 
-import bisect
 import os
 import inspect
 import six
@@ -161,10 +160,11 @@ def interpolate_intervals(intervals, labels, time_points, fill_value=None):
 
     aligned_labels = [fill_value] * len(time_points)
 
-    for (start, end), lab in zip(intervals, labels):
-        start_t = bisect.bisect_left(time_points, start)
-        end_t = bisect.bisect_right(time_points, end)
-        aligned_labels[start_t:end_t] = [lab] * (end_t - start_t)
+    starts = np.searchsorted(time_points, intervals[:, 0], side='left')
+    ends = np.searchsorted(time_points, intervals[:, 1], side='right')
+
+    for (start, end, lab) in zip(starts, ends, labels):
+        aligned_labels[start:end] = [lab] * (end - start)
 
     return aligned_labels
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -21,6 +21,17 @@ def test_interpolate_intervals():
             expected_ans)
 
 
+@nose.tools.raises(ValueError)
+def test_interpolate_intervals_badtime():
+    """Check that interpolate_intervals throws an exception if
+    input is unordered.
+    """
+    labels = list('abc')
+    intervals = np.array([(n, n + 1.0) for n in range(len(labels))])
+    time_points = [-1.0, 0.1, 0.9, 0.8, 2.3, 4.0]
+    mir_eval.util.interpolate_intervals(intervals, labels, time_points)
+
+
 def test_intervals_to_samples():
     """Check that an interval set is sampled properly, with boundaries
     conditions and out-of-range values.

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -21,6 +21,16 @@ def test_interpolate_intervals():
             expected_ans)
 
 
+def test_interpolate_intervals_gap():
+    """Check that an interval set is interpolated properly, with gaps."""
+    labels = list('abc')
+    intervals = np.array([[0.5, 1.0], [1.5, 2.0], [2.5, 3.0]])
+    time_points = [0.0, 0.75, 1.25, 1.75, 2.25, 2.75, 3.5]
+    expected_ans = ['N', 'a', 'N', 'b', 'N', 'c', 'N']
+    assert (util.interpolate_intervals(intervals, labels, time_points, 'N') ==
+            expected_ans)
+
+
 @nose.tools.raises(ValueError)
 def test_interpolate_intervals_badtime():
     """Check that interpolate_intervals throws an exception if


### PR DESCRIPTION
This PR rewrites `util.interpolate_intervals` to support gaps in the intervals properly.

For now, I added documentation to indicate that `time_points` should be in ascending order.  We can either tighten this by adding a validation check, or loosen it and extend the function to support unordered time grids.