### PR TITLE
Ejh 20170704 extended chord mapping

### DIFF
--- a/mir_eval/chord.py
+++ b/mir_eval/chord.py
@@ -414,6 +414,7 @@ def split(chord_label, reduce_extended_chords=False):
 
     if reduce_extended_chords:
         quality, addl_scale_degrees = reduce_extended_quality(quality)
+        print(quality, addl_scale_degrees)
         scale_degrees.update(addl_scale_degrees)
 
     return [chord_root, quality, scale_degrees, bass]

--- a/mir_eval/chord.py
+++ b/mir_eval/chord.py
@@ -177,6 +177,9 @@ def scale_degree_to_semitone(scale_degree):
     semitone : int
         Relative semitone of the scale degree, wrapped to a single octave
 
+    Raises
+    ------
+    InvalidChordException if `scale_degree` is invalid.
     """
     semitone = 0
     offset = 0
@@ -190,7 +193,8 @@ def scale_degree_to_semitone(scale_degree):
     semitone = SCALE_DEGREES.get(scale_degree, None)
     if semitone is None:
         raise InvalidChordException(
-            "Scale degree improperly formed: %s" % scale_degree)
+            "Scale degree improperly formed: {}, expected one of {}."
+            .format(scale_degree, list(SCALE_DEGREES.keys())))
     return semitone + offset
 
 

--- a/mir_eval/chord.py
+++ b/mir_eval/chord.py
@@ -418,7 +418,6 @@ def split(chord_label, reduce_extended_chords=False):
 
     if reduce_extended_chords:
         quality, addl_scale_degrees = reduce_extended_quality(quality)
-        print(quality, addl_scale_degrees)
         scale_degrees.update(addl_scale_degrees)
 
     return [chord_root, quality, scale_degrees, bass]

--- a/mir_eval/chord.py
+++ b/mir_eval/chord.py
@@ -198,7 +198,7 @@ def scale_degree_to_semitone(scale_degree):
     return semitone + offset
 
 
-def scale_degree_to_bitmap(scale_degree):
+def scale_degree_to_bitmap(scale_degree, modulo=False, length=BITMAP_LENGTH):
     """Create a bitmap representation of a scale degree.
 
     Note that values in the bitmap may be negative, indicating that the
@@ -208,21 +208,25 @@ def scale_degree_to_bitmap(scale_degree):
     ----------
     scale_degree : str
         Spelling of a relative scale degree, e.g. 'b3', '7', '#5'
+    modulo : bool, default=True
+        If a scale degree exceeds the length of the bit-vector, modulo the
+        scale degree back into the bit-vector; otherwise it is discarded.
+    length : int, default=12
+        Length of the bit-vector to produce
 
     Returns
     -------
-    bitmap : np.ndarray, in [-1, 0, 1]
-        Bitmap representation of this scale degree (12-dim).
-
+    bitmap : np.ndarray, in [-1, 0, 1], len=`length`
+        Bitmap representation of this scale degree.
     """
     sign = 1
     if scale_degree.startswith("*"):
         sign = -1
         scale_degree = scale_degree.strip("*")
-    edit_map = [0] * BITMAP_LENGTH
+    edit_map = [0] * length
     sd_idx = scale_degree_to_semitone(scale_degree)
-    if sd_idx < BITMAP_LENGTH:
-        edit_map[sd_idx % BITMAP_LENGTH] = sign
+    if sd_idx < length or modulo:
+        edit_map[sd_idx % length] = sign
     return np.array(edit_map)
 
 
@@ -496,7 +500,8 @@ def encode(chord_label, reduce_extended_chords=False,
     semitone_bitmap[0] = 1
 
     for scale_degree in scale_degrees:
-        semitone_bitmap += scale_degree_to_bitmap(scale_degree)
+        semitone_bitmap += scale_degree_to_bitmap(scale_degree,
+                                                  reduce_extended_chords)
 
     semitone_bitmap = (semitone_bitmap > 0).astype(np.int)
     if not semitone_bitmap[bass_number] and strict_bass_intervals:

--- a/tests/test_chord.py
+++ b/tests/test_chord.py
@@ -72,7 +72,14 @@ def test_scale_degree_to_bitmap():
 
     for scale_degree, bitmap in zip(valid_degrees, valid_bitmaps):
         yield (__check_bitmaps, mir_eval.chord.scale_degree_to_bitmap,
-               (scale_degree,), np.array(bitmap))
+               (scale_degree, True, 12), np.array(bitmap))
+
+    yield (__check_bitmaps, mir_eval.chord.scale_degree_to_bitmap,
+           ('9', False, 12), np.array([0] * 12))
+
+    yield (__check_bitmaps, mir_eval.chord.scale_degree_to_bitmap,
+           ('9', False, 15),
+           np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]))
 
 
 def test_validate_chord_label():
@@ -161,8 +168,8 @@ def test_encode():
                        strict_bass_intervals):
         ''' Helper function for checking encode '''
         root, intervals, bass = mir_eval.chord.encode(
-          label, reduce_extended_chords=reduce_extended_chords,
-          strict_bass_intervals=strict_bass_intervals)
+            label, reduce_extended_chords=reduce_extended_chords,
+            strict_bass_intervals=strict_bass_intervals)
         assert root == expected_root, (root, expected_root)
         assert np.all(intervals == expected_intervals), (intervals,
                                                          expected_intervals)

--- a/tests/test_chord.py
+++ b/tests/test_chord.py
@@ -44,14 +44,14 @@ def test_pitch_class_to_semitone():
 
 
 def test_scale_degree_to_semitone():
-    valid_degrees = ['b7', '#3', '1', 'b1', '#7', 'bb5']
-    valid_semitones = [10, 5, 0, -1, 12, 5]
+    valid_degrees = ['b7', '#3', '1', 'b1', '#7', 'bb5', '11', '#13']
+    valid_semitones = [10, 5, 0, -1, 12, 5, 17, 22]
 
     for scale_degree, semitone in zip(valid_degrees, valid_semitones):
         yield (__check_valid, mir_eval.chord.scale_degree_to_semitone,
                (scale_degree,), semitone)
 
-    invalid_degrees = ['7b', '4#', '77']
+    invalid_degrees = ['7b', '4#', '77', '15']
 
     for scale_degree in invalid_degrees:
         yield (__check_exception, mir_eval.chord.scale_degree_to_semitone,


### PR DESCRIPTION
Resolves issue #251.

**Diagnosis:** The method `scale_degree_to_bitmap` in `mir_eval.chord` was only ever dropping extended scale degrees on the floor, regardless of whether or not `reduce_extended_chords` was set. This resulted in unexpected behavior when `reduce_extended_chords=True`, because one expects that the extended scale degrees would be folded into the bit-vector representation.

**Fix:** Two arguments were added to `scale_degree_to_bitmap`: `modulo` and `length`, defaulting to `False` and `12` respectively, which preserves the same behavior of `mir_eval` overall. Then, in the `encode` method, `reduce_extended_chords` is passed on to `modulo`. This also preserves the consistent behavior of `mir_eval`, while fixing the expected behavior of these methods.

This will be of interest to @fdlm and @bmcfee, having weighed in on the issue.