### PR TITLE
Faster matching of events

### DIFF
--- a/mir_eval/util.py
+++ b/mir_eval/util.py
@@ -680,7 +680,7 @@ def _outer_distance(ref, est):
     return np.abs(np.subtract.outer(ref, est))
 
 
-def match_events(ref, est, window, distance=_outer_distance):
+def match_events(ref, est, window, distance=None):
     """Compute a maximum matching between reference and estimated event times,
     subject to a window constraint.
 
@@ -702,7 +702,7 @@ def match_events(ref, est, window, distance=_outer_distance):
         Size of the window.
     distance : function
         function that computes the outer distance of ref and est.
-        By default uses _outer_distance, ``|ref[i] - est[j]|``
+        By default uses ``|ref[i] - est[j]|``
 
     Returns
     -------
@@ -711,11 +711,11 @@ def match_events(ref, est, window, distance=_outer_distance):
         ``matching[i] == (i, j)`` where ``ref[i]`` matches ``est[j]``.
 
     """
-    if distance is None:
-        distance = _outer_distance
-
-    # Compute the indices of feasible pairings
-    hits = np.where(distance(ref, est) <= window)
+    if distance is not None:
+        # Compute the indices of feasible pairings
+        hits = np.where(distance(ref, est) <= window)
+    else:
+        hits = _fast_hit_windows(ref, est, window)
 
     # Construct the graph input
     G = {}
@@ -728,6 +728,46 @@ def match_events(ref, est, window, distance=_outer_distance):
     matching = sorted(_bipartite_match(G).items())
 
     return matching
+
+
+def _fast_hit_windows(ref, est, window):
+    '''Fast calculation of windowed hits for time events.
+
+    Given two lists of event times ``ref`` and ``est``, and a
+    tolerance window, computes a list of pairings
+    ``(i, j)`` where ``|ref[i] - est[j]| <= window``.
+
+    Parameters
+    ----------
+    ref : np.ndarray, shape=(n,)
+        Array of reference values
+    est : np.ndarray, shape=(m,)
+        Array of estimated values
+    window : float >= 0
+        Size of the tolerance window
+
+    Returns
+    -------
+    ref_idx : np.ndarray
+    est_idx : np.ndarray
+        indices such that ``|ref_idx[i] - est_idx[i]| <= window``
+    '''
+
+    ref = np.asarray(ref)
+    est = np.asarray(est)
+    ref_idx = np.argsort(ref)
+    ref_sorted = ref[ref_idx]
+
+    left_idx = np.searchsorted(ref_sorted, est - window, side='left')
+    right_idx = np.searchsorted(ref_sorted, est + window, side='right')
+
+    hit_ref = []
+    hit_est = []
+    for j, (start, end) in enumerate(zip(left_idx, right_idx)):
+        for i in range(start, end):
+            hit_ref.append(ref_idx[i])
+            hit_est.append(j)
+    return hit_ref, hit_est
 
 
 def validate_intervals(intervals):

--- a/mir_eval/util.py
+++ b/mir_eval/util.py
@@ -737,6 +737,11 @@ def _fast_hit_windows(ref, est, window):
     tolerance window, computes a list of pairings
     ``(i, j)`` where ``|ref[i] - est[j]| <= window``.
 
+    This is equivalent to, but more efficient than the following:
+
+    >>> hit_ref, hit_est = np.where(np.abs(np.subtract.outer(ref, est))
+    ...                             <= window)
+
     Parameters
     ----------
     ref : np.ndarray, shape=(n,)
@@ -748,9 +753,9 @@ def _fast_hit_windows(ref, est, window):
 
     Returns
     -------
-    ref_idx : np.ndarray
-    est_idx : np.ndarray
-        indices such that ``|ref_idx[i] - est_idx[i]| <= window``
+    hit_ref : np.ndarray
+    hit_est : np.ndarray
+        indices such that ``|hit_ref[i] - hit_est[i]| <= window``
     '''
 
     ref = np.asarray(ref)

--- a/mir_eval/util.py
+++ b/mir_eval/util.py
@@ -766,12 +766,12 @@ def _fast_hit_windows(ref, est, window):
     left_idx = np.searchsorted(ref_sorted, est - window, side='left')
     right_idx = np.searchsorted(ref_sorted, est + window, side='right')
 
-    hit_ref = []
-    hit_est = []
+    hit_ref, hit_est = [], []
+
     for j, (start, end) in enumerate(zip(left_idx, right_idx)):
-        for i in range(start, end):
-            hit_ref.append(ref_idx[i])
-            hit_est.append(j)
+        hit_ref.extend(ref_idx[start:end])
+        hit_est.extend([j] * (end - start))
+
     return hit_ref, hit_est
 
 

--- a/mir_eval/util.py
+++ b/mir_eval/util.py
@@ -660,26 +660,6 @@ def _outer_distance_mod_n(ref, est, modulus=12):
     return np.minimum(abs_diff, modulus - abs_diff)
 
 
-def _outer_distance(ref, est):
-    """Compute the absolute outer distance.
-    Computes |ref[i] - est[j]| for each i and j.
-
-    Parameters
-    ----------
-    ref : np.ndarray, shape=(n,)
-        Array of reference values.
-    est : np.ndarray, shape=(m,)
-        Array of estimated values.
-
-    Returns
-    -------
-    outer_distance : np.ndarray, shape=(n, m)
-        The outer 1d-euclidean distance.
-
-    """
-    return np.abs(np.subtract.outer(ref, est))
-
-
 def match_events(ref, est, window, distance=None):
     """Compute a maximum matching between reference and estimated event times,
     subject to a window constraint.

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -201,17 +201,6 @@ def test_outer_distance_mod_n():
     assert np.allclose(actual, expected)
 
 
-def test_outer_distance():
-    ref = [1., 2., 3.]
-    est = [1.1, 6., 1.9, 5., 10.]
-    expected = np.array([
-        [0.1, 5., 0.9, 4., 9.],
-        [0.9, 4., 0.1, 3., 8.],
-        [1.9, 3., 1.1, 2., 7.]])
-    actual = mir_eval.util._outer_distance(ref, est)
-    assert np.allclose(actual, expected)
-
-
 def test_match_events():
     ref = [1., 2., 3.]
     est = [1.1, 6., 1.9, 5., 10.]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -227,6 +227,18 @@ def test_match_events():
     assert actual == expected
 
 
+def test_fast_hit_windows():
+
+    ref = [1., 2., 3.]
+    est = [1.1, 6., 1.9, 5., 10.]
+
+    ref_fast, est_fast = mir_eval.util._fast_hit_windows(ref, est, 0.5)
+    ref_slow, est_slow = np.where(np.abs(np.subtract.outer(ref, est)) <= 0.5)
+
+    assert np.all(ref_fast == ref_slow)
+    assert np.all(est_fast == est_slow)
+
+
 def test_validate_intervals():
     # Test for ValueError when interval shape is invalid
     nose.tools.assert_raises(


### PR DESCRIPTION
Ths PR addresses #257 by doing a sorted bisection search for finding matched events, rather than building an all-pairs distance matrix.  The latter is still supported for fancy distance metrics, as is used in multipitch eval.

Quick benchmark:
```python

In [5]: est = np.random.randn(1000)

In [6]: ref = np.random.randn(10000) * 100

In [7]: %timeit mir_eval.util.match_events(ref, est, window=0.5)
57.4 ms ± 381 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [8]: %timeit mir_eval.util.match_events(ref, est, window=0.5, distance=mir_eval.util._outer_distance)
183 ms ± 1.52 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [9]: est = np.random.randn(10000)

In [10]: %timeit mir_eval.util.match_events(ref, est, window=0.5, distance=mir_eval.util._outer_distance)
1.88 s ± 46.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [11]: %timeit mir_eval.util.match_events(ref, est, window=0.5)
536 ms ± 5.13 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```