### PR TITLE
Run PEP8 tests after nosetests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,9 @@ before_install:
 install:
     - pip install -e .[display,testing]
 
-before_script:
-    - pep8 mir_eval evaluators tests
-
 script:
     - nosetests -v --with-coverage --cover-package=mir_eval -w tests
+    - pep8 mir_eval evaluators tests
     - python setup.py build_sphinx
     - python setup.py egg_info -b.dev sdist --formats gztar
 


### PR DESCRIPTION
This PR just re-orders the tests in travis, as per previous discussion with @craffel.

