### PR TITLE
added fix for comma instead of dot in floating point numbers

### DIFF
--- a/mir_eval/io.py
+++ b/mir_eval/io.py
@@ -90,6 +90,7 @@ def load_delimited(filename, converters, delimiter=r'\s+'):
             for value, column, converter in zip(data, columns, converters):
                 # Try converting the value, throw a helpful error on failure
                 try:
+                    value = value.replace(',' , '.')
                     converted_value = converter(value)
                 except:
                     raise ValueError("Couldn't convert value {} using {} "


### PR DESCRIPTION
When there is a timestamp stored in a text file with comma instead of dot for dividing the whole number from the mantissa (e.g. 1,23 instead of 1.23), [load_delimited](https://github.com/craffel/mir_eval/blob/master/mir_eval/io.py#L93) throws an error.  