### PR TITLE
WIP: BSSEval v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
     - "2.7"
     - "3.4"
     - "3.5"
+    - "3.6"
 
 before_install:
     - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
@@ -21,7 +22,7 @@ before_install:
     - conda update -q conda
     - conda info -a
     - deps='pip atlas numpy scipy sphinx nose six future pep8 matplotlib decorator'
-    - conda create -q -n test-environment "python=$TRAVIS_PYTHON_VERSION" $deps 
+    - conda create -q -n test-environment "python=$TRAVIS_PYTHON_VERSION" $deps
     - source activate test-environment
     - pip install python-coveralls
     - pip install numpydoc
@@ -30,7 +31,7 @@ install:
     - pip install -e .[display,testing]
 
 script:
-    - nosetests -v --with-coverage --cover-package=mir_eval -w tests
+    - nosetests -v --with-coverage --cover-package=mir_eval -w tests -s test_separation
     - pep8 mir_eval evaluators tests
     - python setup.py build_sphinx
     - python setup.py egg_info -b.dev sdist --formats gztar

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
     - pip install -e .[display,testing]
 
 script:
-    - nosetests -v --with-coverage --cover-package=mir_eval -w tests -s test_separation
+    - nosetests -v --with-coverage --cover-package=mir_eval -w tests
     - pep8 mir_eval evaluators tests
     - python setup.py build_sphinx
     - python setup.py egg_info -b.dev sdist --formats gztar

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -659,7 +659,7 @@ def _safe_db(num, den):
     RuntimeWarning.
     """
     if den == 0:
-        return np.nan
+        return np.inf
     return 10 * np.log10(num / den)
 
 

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -35,13 +35,13 @@ Metrics
 
 References
 ----------
-  .. [#liutkus2018bssevalv4] Antoine Liutkus, Fabian-Robert Stöter and Nobutaka
+  .. Antoine Liutkus, Fabian-Robert Stöter and Nobutaka
      Ito, "The 2018 Signal Separation Evaluation Campaign," In Proceedings of
      LVA/ICA 2018.
-  .. [#vincent2005bssevalv3] Emmanuel Vincent, Rémi Gribonval, and Cédric
+  .. Emmanuel Vincent, Rémi Gribonval, and Cédric
       Févotte, "Performance measurement in blind audio source separation," IEEE
       Trans. on Audio, Speech and Language Processing, 14(4):1462-1469, 2006.
-  .. [#fevotte2005bssevalv2] Cédric Févotte, Rémi Gribonval and Emmanuel
+  .. Cédric Févotte, Rémi Gribonval and Emmanuel
      Vincent, "BSS_EVAL toolbox user guide - Revision 2.0", Technical Report
      1706, IRISA, April 2005."""
 
@@ -136,7 +136,7 @@ def bss_eval(reference_sources, estimated_sources,
     Measurement of the separation quality for estimated source signals
     in terms of source to distortion, interference and artifacts ratios,
     (SDR, SIR, SAR) as well as the image to spatial ratio (ISR), as defined
-    in [#vincent2005bssevalv3]
+    in [#vincent2005bssevalv3]_.
 
     The metrics are computed on a framewise basis, with overlap allowed between
     the windows.
@@ -659,7 +659,7 @@ def _safe_db(num, den):
     RuntimeWarning.
     """
     if den == 0:
-        return np.Inf
+        return np.nan
     return 10 * np.log10(num / den)
 
 
@@ -669,13 +669,15 @@ def evaluate(reference_sources, estimated_sources, **kwargs):
     for any valid input and will additionally compute
     :func:`mir_eval.separation.bss_eval_sources` for valid input with fewer
     than 3 dimensions.
+
     Examples
     --------
     >>> # reference_sources[n] should be an ndarray of samples of the
     >>> # n'th reference source
     >>> # estimated_sources[n] should be the same for the n'th estimated source
     >>> scores = mir_eval.separation.evaluate(reference_sources,
-    ...                                       estimated_sources)
+    >>>                                       estimated_sources)
+
     Parameters
     ----------
     reference_sources : np.ndarray, shape=(nsrc, nsampl[, nchan])
@@ -685,6 +687,7 @@ def evaluate(reference_sources, estimated_sources, **kwargs):
     kwargs
         Additional keyword arguments which will be passed to the
         appropriate metric or preprocessing functions.
+
     Returns
     -------
     scores : dict

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -544,7 +544,7 @@ def _compute_projection_filters(G, sf, estimated_source):
     filters_len-1
     """
     # epsilon
-    eps = np.finfo(np.float32).eps
+    eps = np.finfo(np.float).eps ** 2
 
     # shapes
     (nsampl, nchan) = estimated_source.shape

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -543,6 +543,9 @@ def _compute_projection_filters(G, sf, estimated_source):
     delayed versions of reference sources, with delays between 0 and
     filters_len-1
     """
+    # epsilon
+    eps = np.finfo(np.float32).eps
+
     # shapes
     (nsampl, nchan) = estimated_source.shape
     # handles the case where we are calling this with only one source
@@ -576,7 +579,7 @@ def _compute_projection_filters(G, sf, estimated_source):
 
     # Distortion filters
     try:
-        C = np.linalg.solve(G, D).reshape(
+        C = np.linalg.solve(G + eps*np.eye(nsrc), D).reshape(
             nsrc, nchan, filters_len, nchan, order='F'
         )
     except np.linalg.linalg.LinAlgError:

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -544,7 +544,7 @@ def _compute_projection_filters(G, sf, estimated_source):
     filters_len-1
     """
     # epsilon
-    eps = np.finfo(np.float).eps ** 2
+    eps = np.finfo(np.float).eps
 
     # shapes
     (nsampl, nchan) = estimated_source.shape

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -302,9 +302,15 @@ def bss_eval(reference_sources, estimated_sources,
                     s_true, e_spat, e_interf, e_artif = \
                         _bss_decomp_mtifilt(
                             reference_sources[:, win],
-                            estimated_sources[jest, win], jtrue, C[jest], Cj[jtrue, jest, 0])
+                            estimated_sources[jest, win], jtrue, C[jest],
+                            Cj[jtrue, jest, 0]
+                        )
                     s_r[:, jtrue, jest, t] = _bss_crit(
-                        s_true, e_spat, e_interf, e_artif, bsseval_sources_version
+                        s_true,
+                        e_spat,
+                        e_interf,
+                        e_artif,
+                        bsseval_sources_version
                     )
                     done[jtrue, jest] = True
 
@@ -495,8 +501,8 @@ def _compute_reference_correlations(reference_sources, filters_len):
     """Compute the inner products between delayed versions of reference_sources
     reference is nsrc X nsamp X nchan.
     Returns
-    * the gram matrix G : nsrc X nsrc X nchan X nchan X filters_len X filters_len
-    * the references spectra sf: nsrc X nchan X filters_len"""
+    * G, matrix : nsrc X nsrc X nchan X nchan X filters_len X filters_len
+    * sf, reference spectra: nsrc X nchan X filters_len"""
 
     # reshape references as nsrc X nchan X nsampl
     (nsrc, nsampl, nchan) = reference_sources.shape
@@ -509,9 +515,9 @@ def _compute_reference_correlations(reference_sources, filters_len):
 
     # compute intercorrelation between sources
     G = np.zeros((nsrc, nsrc, nchan, nchan, filters_len, filters_len))
-    # for ((i, c1), (j, c2)) in itertools.combinations_with_replacement(
-    #                        itertools.product(range(nsrc), range(nchan)), 2):
-    for ((i, c1, j, c2)) in itertools.product(*(range(nsrc), range(nchan)) * 2):
+    for ((i, c1), (j, c2)) in itertools.combinations_with_replacement(
+                           itertools.product(range(nsrc), range(nchan)), 2):
+    # for ((i, c1, j, c2)) in itertools.product(*(range(nsrc), range(nchan)) * 2):
 
         ssf = sf[j, c2] * np.conj(sf[i, c1])
         ssf = np.real(scipy.fftpack.ifft(ssf))
@@ -520,7 +526,7 @@ def _compute_reference_correlations(reference_sources, filters_len):
             r=ssf[:filters_len]
         )
         G[j, i, c2, c1] = ss
-        #G[i, j, c1, c2] = ss.T
+        G[i, j, c1, c2] = ss.T
     return G, sf
 
 

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -422,11 +422,11 @@ def bss_eval_images_framewise(reference_sources, estimated_sources,
 # Helper functions
 class Framing:
     """ helper iterator class to do overlapped windowing"""
-    def __init__(self, window, hop, len):
+    def __init__(self, window, hop, length):
         self.current = 0
         self.window = window
         self.hop = hop
-        self.len = len
+        self.length = length
 
     def __iter__(self):
         return self
@@ -438,18 +438,18 @@ class Framing:
             start = self.current * self.hop
             if np.isnan(start) or np.isinf(start):
                 start = 0
-            stop = min(self.current * self.hop + self.window, self.len)
+            stop = min(self.current * self.hop + self.window, self.length)
             if np.isnan(stop) or np.isinf(stop):
-                stop = self.len
+                stop = self.length
             result = slice(start, stop)
             self.current += 1
             return result
 
     @property
     def nwin(self):
-        if self.window < len:
+        if self.window < self.length:
             return int(
-                np.floor((len - self.window + self.hop) / self.hop)
+                np.floor((self.length - self.window + self.hop) / self.hop)
             )
         else:
             return 1

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -10,7 +10,7 @@ attempt to measure the perceptual quality of the separation.
 See also the bss_eval MATLAB toolbox:
     http://bass-db.gforge.inria.fr/bss_eval/
 
-Conventions
+Conventions 
 -----------
 
 An audio signal is expected to be in the format of a 2-dimensional array where

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -497,7 +497,7 @@ def _reshape_G(G):
     G = np.moveaxis(G, (1, 3), (3, 4))
     (nsrc, nchan, filters_len) = G.shape[0:3]
     G = np.reshape(
-        G, (nsrc * nchan * filters_len, nsrc * nchan * filters_len), order="F"
+        G, (nsrc * nchan * filters_len, nsrc * nchan * filters_len)
     )
     return G
 
@@ -574,17 +574,17 @@ def _compute_projection_filters(G, sf, estimated_source):
         D[j, cj, :, c] = np.hstack((ssef[0], ssef[-1:-filters_len:-1]))
 
     # reshape matrices to build the filters
-    D = D.reshape(nsrc * nchan * filters_len, nchan, order='F')
+    D = D.reshape(nsrc * nchan * filters_len, nchan)
     G = _reshape_G(G)
 
     # Distortion filters
     try:
         C = np.linalg.solve(G + eps*np.eye(G.shape[0]), D).reshape(
-            nsrc, nchan, filters_len, nchan, order='F'
+            nsrc, nchan, filters_len, nchan
         )
     except np.linalg.linalg.LinAlgError:
         C = np.linalg.lstsq(G, D)[0].reshape(
-            nsrc, nchan, filters_len, nchan, order='F'
+            nsrc, nchan, filters_len, nchan
         )
 
     # if we asked for one single reference source,

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
+BSS Eval toolbox, version 4
+
 Source separation algorithms attempt to extract recordings of individual
 sources from a recording of a mixture of sources.  Evaluation methods for
 source separation compare the extracted sources from reference sources and
@@ -22,20 +24,26 @@ channels.
 Metrics
 -------
 
-* :func:`mir_eval.separation.bss_eval`: Computes the bss_eval metrics from
-  bss_eval. First, it matches the estimated sources to the references through
-  time-invariant filters. Then, it computes the source to distortion (SDR),
-  source to artifacts (SAR), source to interference (SIR) ratios, plus the
-  image to spatial ratio (ISR) for multichannel signals.
-  These are computed on a frame by frame basis, (with infinite window size
-  meaning the whole signal). Metrics correspond to the bsseval_images version,
-  but may optionally correspond to the (deprecated) bsseval_sources version.
+* :func:`mir_eval.separation.bss_eval`: Computes the bss_eval metrics: source
+  to distortion (SDR), source to artifacts (SAR), source to interference (SIR)
+  ratios, plus the image to spatial ratio (ISR). These are computed on a frame
+  by frame basis, (with infinite window size meaning the whole signal).
+
+  Optionally, the distortion filters are time-varying, corresponding to behavior
+  of BSS Eval version 3. Furthermore, metrics may optionally correspond to the
+  bsseval_sources version, as defined in the BSS Eval version 2.
 
 References
 ----------
-  .. [#vincent2006performance] Emmanuel Vincent, Rémi Gribonval, and Cédric
+  .. [#liutkus2018bssevalv4] Antoine Liutkus, Fabian-Robert Stöter and Nobutaka
+     Ito, "The 2018 Signal Separation Evaluation Campaign," In Proceedings of
+     LVA/ICA 2018.
+  .. [#vincent2005bssevalv3] Emmanuel Vincent, Rémi Gribonval, and Cédric
       Févotte, "Performance measurement in blind audio source separation," IEEE
       Trans. on Audio, Speech and Language Processing, 14(4):1462-1469, 2006.
+  .. [#fevotte2005bssevalv2] Cédric Févotte, Rémi Gribonval and Emmanuel
+     Vincent, "BSS_EVAL toolbox user guide - Revision 2.0", Technical Report
+     1706, IRISA, April 2005.
 
 '''
 

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -331,12 +331,13 @@ def bss_eval(reference_sources, estimated_sources,
 
     # now prepare the output
     if not framewise_filters:
-        return (*(s_r[:, dum, popt[:, 0], :]), popt)
+        result = s_r[:, dum, popt[:, 0], :]
     else:
         result = np.empty((4, nsrc, nwin))
         for (m, t) in itertools.product(range(4), range(nwin)):
             result[m, :, t] = s_r[m, dum, popt[:, t], t]
-        return (*result, popt)
+
+    return (result[SDR], result[ISR], result[SIR], result[SAR], popt)
 
 
 def bss_eval_sources(reference_sources, estimated_sources,

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -454,6 +454,8 @@ class Framing:
         else:
             return 1
 
+    next = __next__
+
 
 def _bss_decomp_mtifilt(reference_sources, estimated_source, j, C, Cj):
     """Decomposition of an estimated source image into four components

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -301,17 +301,19 @@ def bss_eval(reference_sources, estimated_sources,
 
         ref_slice = reference_sources[:, win]
         est_slice = estimated_sources[:, win]
-        if (not _any_source_silent(ref_slice) and
-            not _any_source_silent(est_slice)):
-
+        if (
+            not _any_source_silent(ref_slice) and
+            not _any_source_silent(est_slice)
+        ):
             for jtrue in range(nsrc):
                 for (k, jest) in enumerate(candidate_permutations[:, jtrue]):
-                # if we have a silent frame set results as np.nan
+                    # if we have a silent frame set results as np.nan
                     if not done[jtrue, jest]:
                             s_true, e_spat, e_interf, e_artif = \
                                 _bss_decomp_mtifilt(
                                     reference_sources[:, win],
-                                    estimated_sources[jest, win], jtrue, C[jest],
+                                    estimated_sources[jest, win],
+                                    jtrue, C[jest],
                                     Cj[jtrue, jest, 0]
                                 )
                             s_r[:, jtrue, jest, t] = _bss_crit(

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -255,7 +255,7 @@ def bss_eval(reference_sources, estimated_sources,
         mean_sir[i] = np.mean(s_r[SIR,perm, dum,:])
     popt = candidate_permutations[np.argmax(mean_sir)]
     idx = (popt, dum)
-    return (*np.squeeze(s_r[:,popt,dum,:]),np.squeeze(popt.T))
+    return (*(s_r[:,popt,dum,:]),np.squeeze(popt.T))
 
 def bss_eval_sources(reference_sources, estimated_sources,
                      compute_permutation=True):

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -10,7 +10,7 @@ attempt to measure the perceptual quality of the separation.
 See also the bss_eval MATLAB toolbox:
     http://bass-db.gforge.inria.fr/bss_eval/
 
-Conventions 
+Conventions
 -----------
 
 An audio signal is expected to be in the format of a 2-dimensional array where
@@ -59,7 +59,6 @@ from . import util
 # The maximum allowable number of sources (prevents insane computational load)
 MAX_SOURCES = 100
 
-
 def validate(reference_sources, estimated_sources):
     """Checks that the input data to a metric are valid, and throws helpful
     errors if not.
@@ -74,7 +73,7 @@ def validate(reference_sources, estimated_sources):
     """
     if reference_sources.shape != estimated_sources.shape:
         raise ValueError('The shape of estimated sources and the true '
-                         'sources should match.  reference_sources.shape '
+                         'sources should match. reference_sources.shape '
                          '= {}, estimated_sources.shape '
                          '= {}'.format(reference_sources.shape,
                                        estimated_sources.shape))
@@ -88,7 +87,7 @@ def validate(reference_sources, estimated_sources):
 
     if reference_sources.size == 0:
         warnings.warn("reference_sources is empty, should be of size "
-                      "(nsrc, nsample, nchan). sdr, sir, sar, and perm will"
+                      "(nsrc, nsample, nchan). sdr, isr sir, sar, and perm will"
                       " all be empty np.ndarrays")
     elif _any_source_silent(reference_sources):
         raise ValueError('All the reference sources should be non-silent (not '
@@ -99,8 +98,8 @@ def validate(reference_sources, estimated_sources):
 
     if estimated_sources.size == 0:
         warnings.warn("estimated_sources is empty, should be of size "
-                      "(nsrc, nsample, nchan).  sdr, sir, sar, and perm will "
-                      "all be empty np.ndarrays")
+                      "(nsrc, nsample, nchan).  sdr, isr, sir, sar, and perm "
+                      "will all be empty np.ndarrays")
     elif _any_source_silent(estimated_sources):
         raise ValueError('All the estimated sources should be non-silent (not '
                          'all-zeros), but at least one of the estimated '
@@ -113,39 +112,42 @@ def validate(reference_sources, estimated_sources):
         raise ValueError('The supplied matrices should be of shape (nsrc,'
                          ' nsampl, nchan) but reference_sources.shape[0] = {} '
                          'and estimated_sources.shape[0] = {} which is greater'
-                         'than mir_eval.separation.MAX_SOURCES = {}.  To '
+                         'than bsseval.MAX_SOURCES = {}.  To '
                          'override this check, set '
-                         'mir_eval.separation.MAX_SOURCES to a '
+                         'bsseval.MAX_SOURCES to a '
                          'larger value.'.format(reference_sources.shape[0],
                                                 estimated_sources.shape[0],
                                                 MAX_SOURCES))
-
 
 def _any_source_silent(sources):
     """Returns true if the parameter sources has any silent first dimensions"""
     return np.any(np.all(np.sum(
         sources, axis=tuple(range(2, sources.ndim))) == 0, axis=1))
 
-
 def bss_eval(reference_sources, estimated_sources,
-             window=2*44100, hop=1.5*44100,
-             compute_permutation=False,
-             flen=512,
-             bsseval_sources=False):
-    """Implementation of the bss_eval function, adapted from the
-    BSS_EVAL Matlab toolbox and mir_eval.separation.
+             window = 2*44100, hop = 1.5*44100,
+             compute_permutation = False,
+             filters_len = 512,
+             framewise_filters = False,
+             bsseval_sources_version = False
+):
+    """BSS_EVAL version 4.
 
     Measurement of the separation quality for estimated source signals
-    in terms of filtered true source, interference and artifacts.
-    This method also provides the ISR measure for multichannel signals.
+    in terms of source to distortion, interference and artifacts ratios,
+    (SDR, SIR, SAR) as well as the image to spatial ratio (ISR), as defined
+    in [#vincent2005bssevalv3]
 
-    The decomposition allows a time-invariant filter distortion of length
-    flen=512, as described in Section III.B of [#vincent2006performance]_, and
-    computes the metrics on a windowed basis.
+    The metrics are computed on a framewise basis, with overlap allowed between
+    the windows.
 
-    Passing ``False`` for ``compute_permutation`` will assume the order for
-    the estimated sources matches that of the true sources. Otherwise, all
-    permutations are tested, yielding a significant computation overhead.
+    The key difference between this version 4 and BSS Eval version 3 is the
+    possibility of using the same distortion filters for all windows when
+    matching the sources to their estimates, instead of estimating the filters
+    anew at every frame, as done in BSS Eval v3.
+
+    This implementation is fully compatible with BSS Eval v2 and v3 written
+    in MATLAB.
 
     Examples
     --------
@@ -164,20 +166,31 @@ def bss_eval(reference_sources, estimated_sources,
     estimated_sources : np.ndarray, shape=(nsrc, nsampl, nchan)
         matrix containing estimated sources
     window : int, optional
-        size of each window for time-varying evaluation. Picking np.inf will
-        compute metrics on the whole signal.
+        size of each window for time-varying evaluation. Picking np.inf or any
+        integer greater than nsampl will compute metrics on the whole signal.
     hop : int, optional
         hop size between windows
     compute_permutation : bool, optional
-        compute permutation of estimate/source combinations (True by default)
-    bsseval_sources : bool, optional
-        if  ``True``, results correspond to :func:`bss_eval_sources` from
-        the BSS Eval. Note however that this is not recommended because this
-        evaluation method amounts to modify the references according to the
-        estimated sources, leading to potential problems. For instance, zeroing
-        some frequencies in the estimates will lead those to also be zeroed in
-        the references, and hence not evaluated, artificially boosting results.
-        For this reason, SiSEC always uses the :func:`bss_eval_images` version.
+        compute all permutations of estimate/source combinations to compute
+        the best scores (False by default). Note that picking True will lead
+        to a significant computation overhead.
+    filters_len : int, optional
+        maximum time lag for the computation of the distortion filters. Default
+        is filters_len = 512.
+    framewise_filters : bool, optional
+        Compute a new distortion filter for each frame (False by default). Note
+        that picking True as in BSS Eval v2 and v3 leads to a significant
+        computation overhead.
+    bsseval_sources_version : bool, optional
+        if  ``True``, results correspond to the `bss_eval_sources` version from
+        the BSS Eval v2 and v3. Note however that this is not recommended
+        because this evaluation method modifies the references according to the
+        estimated sources, leading to potential problems for the estimation of
+        SDR. For instance, zeroing some frequencies in the estimates will lead
+        those to also be zeroed in the references, and hence not evaluated,
+        artificially boosting results. For this reason, SiSEC always uses
+        the `bss_eval_images` version, corresponding to ``False``.
+
     Returns
     -------
     sdr : np.ndarray, shape=(nsrc, nwin)
@@ -191,17 +204,19 @@ def bss_eval(reference_sources, estimated_sources,
         matrix of Sources to Artifacts Ratios (SAR)
     perm : np.ndarray, shape=(nsrc, nwin)
         vector containing the best ordering of estimated sources in
-        the mean SIR sense (estimated source number ``perm[j]`` corresponds to
-        true source number ``j``).  Note: ``perm`` will be ``(1,2,...,nsrc)``
-        if ``compute_permutation`` is ``False``.
+        the mean SIR sense (estimated source number ``perm[j,t]`` corresponds to
+        true source number ``j`` at window ``t``).
+        Note: ``perm`` will be ``(0,2,...,nsrc-1)`` if ``compute_permutation``
+        is ``False``.
 
     References
     ----------
-    .. [#] Emmanuel Vincent, Shoko Araki, Fabian J. Theis, Guido Nolte, Pau
-        Bofill, Hiroshi Sawada, Alexey Ozerov, B. Vikrham Gowreesunker, Dominik
-        Lutter and Ngoc Q.K. Duong, "The Signal Separation Evaluation Campaign
-        (2007-2010): Achievements and remaining challenges", Signal Processing,
-        92, pp. 1928-1936, 2012.
+  .. [#liutkus2018bssevalv4] Antoine Liutkus, Fabian-Robert Stöter and Nobutaka
+     Ito, "The 2018 Signal Separation Evaluation Campaign," In Proceedings of
+     LVA/ICA 2018.
+  .. [#vincent2005bssevalv3] Emmanuel Vincent, Rémi Gribonval, and Cédric
+      Févotte, "Performance measurement in blind audio source separation," IEEE
+      Trans. on Audio, Speech and Language Processing, 14(4):1462-1469, 2006.
 
     """
     # make sure the input has 3 dimensions
@@ -222,15 +237,8 @@ def bss_eval(reference_sources, estimated_sources,
             np.array([])
         )
 
-    # determine size parameters
+    # determine shape parameters
     (nsrc, nsampl, nchan) = estimated_sources.shape
-
-    # First compute the time-invariant distortion filters from all refs
-    # to each source
-    G, sf = _compute_reference_correlations(reference_sources, flen)
-    C = np.zeros((nsrc, nsrc, nchan, flen, nchan))
-    for src in range(nsrc):
-        C[src] = _compute_projection_filters(G, sf, estimated_sources[src])
 
     # defines all the permutations desired by user
     if compute_permutation:
@@ -239,49 +247,90 @@ def bss_eval(reference_sources, estimated_sources,
     else:
         candidate_permutations = np.array(range(nsrc))[None, :]
 
-    # prepare criteria variable for all possible pair matches and
     # initialize variables
-    if window < nsampl:
-        nwin = int(
-            np.floor((reference_sources.shape[1] - window + hop) / hop)
-            )
-    else:
-        nwin = 1
+    nwin = Framing.count(window, hop, nsampl)
+    #print('\n--------\n','nsrc = %d, nsampl=%d, nchan=%d,nwin=%d'%(nsrc,nsampl,nchan,nwin),'\n---------\n')
 
     (SDR, ISR, SIR, SAR) = range(4)
     s_r = np.empty((4, nsrc, nsrc, nwin))
-    done = np.zeros((nsrc, nsrc))
-    for jtrue in range(nsrc):
-        for (k, jest) in enumerate(candidate_permutations[:, jtrue]):
-            if not done[jest, jtrue]:
-                # need to compute the scores for this combination
-                Cj = _compute_projection_filters(
+
+    # define helper functions for computing filters on windows of the signals
+    def compute_GsfC(win = slice(0, nsampl)):
+        # First compute the references correlations
+        G, sf = _compute_reference_correlations(reference_sources[:,win], filters_len)
+        # compute the interference distortion filters
+        C = np.zeros((nsrc, nsrc, nchan, filters_len, nchan))
+        for jtrue in range(nsrc):
+            C[jtrue] = _compute_projection_filters(G, sf, estimated_sources[jtrue,win])
+        return (G,sf,C)
+    def compute_Cj(win = slice(0, nsampl)):
+        Cj = np.zeros((nsrc, nsrc, 1, nchan, filters_len, nchan))
+        for jtrue in range(nsrc):
+            for jest in candidate_permutations[:, jtrue]:
+                # compute the projection filters for this combination
+                Cj[jtrue,jest] = _compute_projection_filters(
                     G[jtrue, jtrue],
                     sf[jtrue],
-                    estimated_sources[jest]
+                    estimated_sources[jest,win]
                 )
-                s_true, e_spat, e_interf, e_artif = \
-                    _bss_decomp_mtifilt(
-                        reference_sources,
-                        estimated_sources[jest], jtrue, C[jest], Cj)
-                s_r[:, jest, jtrue, :] = _bss_crit(
-                    s_true, e_spat, e_interf, e_artif,
-                    window, hop, flen, bsseval_sources
-                )
-                done[jest, jtrue] = True
+        return Cj
+
+    if not framewise_filters:
+        # compute filters on whole signals if no framewise filters
+        (G,sf,C) = compute_GsfC()
+        Cj = compute_Cj()
+
+    # loop over all windows
+    for (t,win) in enumerate(Framing(window, hop, nsampl)):
+        # if we have time-varying distortion filters
+        if framewise_filters:
+            (G,sf,C) = compute_GsfC(win)
+            Cj = compute_Cj(win)
+
+        #loop over all permutations
+        done = np.zeros((nsrc,nsrc))
+        for jtrue in range(nsrc):
+            for (k, jest) in enumerate(candidate_permutations[:, jtrue]):
+                if not done[jtrue,jest]:
+                    s_true, e_spat, e_interf, e_artif = \
+                        _bss_decomp_mtifilt(
+                            reference_sources[:,win],
+                            estimated_sources[jest,win], jtrue, C[jest], Cj[jtrue,jest,0])
+                    s_r[:, jtrue, jest, t] = _bss_crit(
+                        s_true, e_spat, e_interf, e_artif, bsseval_sources_version
+                    )
+                    #print(jtrue,jest,t,np.sum(s_true**2),np.sum(reference_sources[:,win]**2),np.sum(e_interf**2),'nrustn')
+                    done[jtrue, jest] = True
 
     # select the best ordering
-    mean_sir = np.empty((len(candidate_permutations),))
+    if framewise_filters:
+        # if we have framewise filters, output one permutation for each window
+        mean_sir = np.empty((len(candidate_permutations),nwin))
+        axis_mean = 0
+    else:
+        # otherwise, output one permutation for the whole signal as the best
+        # average one
+        mean_sir = np.empty((len(candidate_permutations),1))
+        axis_mean = None
     dum = np.arange(nsrc)
     for (i, perm) in enumerate(candidate_permutations):
-        mean_sir[i] = np.mean(s_r[SIR, perm, dum, :])
-    popt = candidate_permutations[np.argmax(mean_sir)]
-    return (*(s_r[:, popt, dum, :]), np.squeeze(popt.T))
+        mean_sir[i] = np.mean(s_r[SIR, dum, perm, :],axis = axis_mean)
+    popt = candidate_permutations[np.argmax(mean_sir,axis=0)].T
 
+    #now prepare the output
+    if not framewise_filters:
+        return (*(s_r[:, dum, popt[:,0], :]), popt)
+    else:
+        result = np.empty((4,nsrc,nwin))
+        for (m,t) in itertools.product(range(4),range(nwin)):
+            result[m,:,t] = s_r[m, dum, popt[:,t], t]
+        return (*result, popt)
 
 def bss_eval_sources(reference_sources, estimated_sources,
                      compute_permutation=True):
     """
+    BSS Eval v3 bss_eval_sources
+
     Wrapper to ``bss_eval`` with the right parameters.
     The call to this function is not recommended. See the description for the
     ``bsseval_sources`` parameter of ``bss_eval``.
@@ -291,8 +340,9 @@ def bss_eval_sources(reference_sources, estimated_sources,
         bss_eval(
             reference_sources, estimated_sources,
             window=np.inf, hop=np.inf,
-            compute_permutation=compute_permutation, flen=512,
-            bsseval_sources=True
+            compute_permutation=compute_permutation, filters_len=512,
+            framewise_filters = True,
+            bsseval_sources_version=True
         )
     return (sdr, sir, sar, perm)
 
@@ -301,6 +351,8 @@ def bss_eval_sources_framewise(reference_sources, estimated_sources,
                                window=30*44100, hop=15*44100,
                                compute_permutation=False):
     """
+    BSS Eval v3 bss_eval_sources_framewise
+
     Wrapper to ``bss_eval`` with the right parameters.
     The call to this function is not recommended. See the description for the
     ``bsseval_sources`` parameter of ``bss_eval``.
@@ -310,28 +362,34 @@ def bss_eval_sources_framewise(reference_sources, estimated_sources,
         bss_eval(
             reference_sources, estimated_sources,
             window=window, hop=hop,
-            compute_permutation=compute_permutation, flen=512,
-            bsseval_sources=True)
+            compute_permutation=compute_permutation, filters_len=512,
+            framewise_filters = True,
+            bsseval_sources_version=True)
     return (sdr, sir, sar, perm)
 
 
 def bss_eval_images(reference_sources, estimated_sources,
                     compute_permutation=True):
     """
+    BSS Eval v3 bss_eval_images
+
     Wrapper to ``bss_eval`` with the right parameters.
 
     """
     return bss_eval(
         reference_sources, estimated_sources,
         window=np.inf, hop=np.inf,
-        compute_permutation=compute_permutation, flen=512,
-        bsseval_sources=False)
+        compute_permutation=compute_permutation, filters_len=512,
+        framewise_filters = True,
+        bsseval_sources_version=False)
 
 
 def bss_eval_images_framewise(reference_sources, estimated_sources,
                               window=30*44100, hop=15*44100,
                               compute_permutation=False):
     """
+    BSS Eval v3 bss_eval_images_framewise
+
     Framewise computation of bss_eval_images.
     Wrapper to ``bss_eval`` with the right parameters.
 
@@ -339,9 +397,45 @@ def bss_eval_images_framewise(reference_sources, estimated_sources,
     return bss_eval(
         reference_sources, estimated_sources,
         window=window, hop=hop,
-        compute_permutation=compute_permutation, flen=512,
-        bsseval_sources=False
+        compute_permutation=compute_permutation, filters_len=512,
+        framewise_filters = True,
+        bsseval_sources_version=False
     )
+
+
+#Helper functions
+class Framing:
+    """ helper iterator class to do overlapped windowing"""
+    def count(window, hop,len):
+        if window < len:
+            return int(
+                np.floor((len - window + hop) / hop)
+                )
+        else:
+            return 1
+
+    def __init__(self, window, hop, len):
+        self.current = 0
+        self.window = window
+        self.hop = hop
+        self.len = len
+        self.nwin = Framing.count(window, hop, len)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.current >= self.nwin:
+            raise StopIteration
+        else:
+            start = self.current * self.hop
+            if np.isnan(start) or np.isinf(start):
+                start = 0
+            stop = min(self.current * self.hop + self.window, self.len)
+            if np.isnan(stop) or np.isinf(stop): stop = self.len
+            result = slice(start,stop)
+            self.current += 1
+            return result
 
 
 def _bss_decomp_mtifilt(reference_sources, estimated_source, j, C, Cj):
@@ -350,11 +444,11 @@ def _bss_decomp_mtifilt(reference_sources, estimated_source, j, C, Cj):
     distortion, interference and artifacts, derived from the true source
     images using multichannel time-invariant filters.
     """
-    flen = Cj.shape[-2]
+    filters_len = Cj.shape[-2]
 
     # zero pad
-    s_true = _zeropad(reference_sources[j], flen-1, axis=0)
-    estimated_source = _zeropad(estimated_source, flen-1, axis=0)
+    s_true = _zeropad(reference_sources[j], filters_len-1, axis=0)
+    estimated_source = _zeropad(estimated_source, filters_len-1, axis=0)
 
     # compute appropriate projections
     e_spat = _project(reference_sources[j], Cj) - s_true
@@ -378,90 +472,93 @@ def _zeropad(sig, N, axis=0):
 
 def _reshape_G(G):
     """From a correlation matrix of size
-    nsrc X nsrc X nchan X nchan X flen X flen,
+    nsrc X nsrc X nchan X nchan X filters_len X filters_len,
     creates a new one of size
-    nsrc*nchan*flen X nsrc*nchan*flen"""
+    nsrc*nchan*filters_len X nsrc*nchan*filters_len"""
     G = np.moveaxis(G, (1, 3), (3, 4))
-    (nsrc, nchan, flen) = G.shape[0:3]
-    G = np.reshape(G, (nsrc*nchan*flen, nsrc*nchan*flen), order="F")
+    (nsrc, nchan, filters_len) = G.shape[0:3]
+    G = np.reshape(G, (nsrc*nchan*filters_len, nsrc*nchan*filters_len), order="F")
     return G
 
 
-def _compute_reference_correlations(reference_sources, flen):
+def _compute_reference_correlations(reference_sources, filters_len):
     """Compute the inner products between delayed versions of reference_sources
     reference is nsrc X nsamp X nchan.
     Returns
-    * the gram matrix G : nsrc X nsrc X nchan X nchan X flen X flen
-    * the references spectra sf: nsrc X nchan X flen"""
+    * the gram matrix G : nsrc X nsrc X nchan X nchan X filters_len X filters_len
+    * the references spectra sf: nsrc X nchan X filters_len"""
 
     # reshape references as nsrc X nchan X nsampl
     (nsrc, nsampl, nchan) = reference_sources.shape
     reference_sources = np.moveaxis(reference_sources, (1), (2))
 
     # zero padding and FFT of references
-    reference_sources = _zeropad(reference_sources, flen-1, axis=2)
-    n_fft = int(2**np.ceil(np.log2(nsampl + flen - 1.)))
-    sf = scipy.fftpack.fft(reference_sources, n=n_fft, axis=2)
+    reference_sources = _zeropad(reference_sources, filters_len - 1, axis = 2)
+    n_fft = int(2**np.ceil(np.log2(nsampl + filters_len - 1.)))
+    sf = scipy.fftpack.fft(reference_sources, n = n_fft, axis  = 2)
 
     # compute intercorrelation between sources
-    G = np.zeros((nsrc, nsrc, nchan, nchan, flen, flen))
-    for (i, c1, j, c2) in itertools.product(*(range(nsrc), range(nchan))*2):
-        ssf = sf[i, c1] * np.conj(sf[j, c2])
+    G = np.zeros((nsrc, nsrc, nchan, nchan, filters_len, filters_len))
+    for ((i, c1), (j, c2)) in itertools.combinations_with_replacement(
+                            itertools.product(range(nsrc), range(nchan)), 2):
+        ssf = sf[j, c2] * np.conj(sf[i, c1])
         ssf = np.real(scipy.fftpack.ifft(ssf))
-        G[i, j, c1, c2, ...] = toeplitz(
-            np.hstack((ssf[0], ssf[-1:-flen:-1])),
-            r=ssf[:flen]
-        )
+        ss = toeplitz(
+            np.hstack((ssf[0], ssf[-1:-filters_len:-1])),
+            r=ssf[:filters_len]
+            )
+        G[j, i, c2, c1] = ss
+        G[i, j, c1, c2] = ss.T
     return G, sf
 
 
 def _compute_projection_filters(G, sf, estimated_source):
     """Least-squares projection of estimated source on the subspace spanned by
-    delayed versions of reference sources, with delays between 0 and flen-1
+    delayed versions of reference sources, with delays between 0 and filters_len-1
     """
     # shapes
     (nsampl, nchan) = estimated_source.shape
     # handles the case where we are calling this with only one source
-    # G should be nsrc X nsrc X nchan X nchan X flen X flen
-    # and sf should be nsrc X nchan X flen
+    # G should be nsrc X nsrc X nchan X nchan X filters_len X filters_len
+    # and sf should be nsrc X nchan X filters_len
     if len(G.shape) == 4:
         G = G[None, None, ...]
         sf = sf[None, ...]
     nsrc = G.shape[0]
-    flen = G.shape[-1]
+    filters_len = G.shape[-1]
 
     # zero pad estimates and put chan in first dimension
-    estimated_source = _zeropad(estimated_source.T, flen-1, axis=1)
+    estimated_source = _zeropad(estimated_source.T, filters_len - 1, axis = 1)
 
     # compute its FFT
-    n_fft = int(2**np.ceil(np.log2(nsampl + flen - 1.)))
-    sef = scipy.fftpack.fft(estimated_source, n=n_fft)
+    n_fft = int(2**np.ceil(np.log2(nsampl + filters_len - 1.)))
+    sef = scipy.fftpack.fft(estimated_source, n = n_fft)
 
     # compute the cross-correlations between sources and estimates
-    D = np.zeros((nsrc, nchan, flen, nchan))
+    D = np.zeros((nsrc, nchan, filters_len, nchan))
     for (j, cj, c) in itertools.product(
         range(nsrc), range(nchan), range(nchan)
     ):
         ssef = sf[j, cj] * np.conj(sef[c])
         ssef = np.real(scipy.fftpack.ifft(ssef))
-        D[j, cj, :, c] = np.hstack((ssef[0], ssef[-1:-flen:-1]))
+        D[j, cj, :, c] = np.hstack((ssef[0], ssef[-1:-filters_len:-1]))
 
     # reshape matrices to build the filters
-    D = D.reshape(nsrc*nchan*flen, nchan, order='F')
+    D = D.reshape(nsrc*nchan*filters_len, nchan, order='F')
     G = _reshape_G(G)
 
     # Distortion filters
     try:
         C = np.linalg.solve(G, D).reshape(
-            nsrc, nchan, flen, nchan, order='F'
+            nsrc, nchan, filters_len, nchan, order='F'
         )
     except np.linalg.linalg.LinAlgError:
         C = np.linalg.lstsq(G, D)[0].reshape(
-            nsrc, nchan, flen, nchan, order='F'
+            nsrc, nchan, filters_len, nchan, order='F'
         )
 
     # if we asked for one single reference source,
-    # return just a nchan X flen matrix
+    # return just a nchan X filters_len matrix
     if nsrc == 1:
         C = C[0]
     return C
@@ -470,7 +567,7 @@ def _compute_projection_filters(G, sf, estimated_source):
 def _project(reference_sources, C):
     """Project images using pre-computed filters C
     reference_sources are nsrc X nsampl X nchan
-    C is nsrc X nchan X flen X nchan
+    C is nsrc X nchan X filters_len X nchan
     """
     # shapes: ensure that input is 3d (comprising the source index)
     if len(reference_sources.shape) == 2:
@@ -478,12 +575,11 @@ def _project(reference_sources, C):
         C = C[None, ...]
 
     (nsrc, nsampl, nchan) = reference_sources.shape
-    flen = C.shape[-2]
+    filters_len = C.shape[-2]
 
     # zero pad
-    reference_sources = _zeropad(reference_sources, flen-1, axis=1)
-
-    sproj = np.zeros((nchan, nsampl+flen-1))
+    reference_sources = _zeropad(reference_sources, filters_len-1, axis=1)
+    sproj = np.zeros((nchan, nsampl+filters_len-1))
 
     for (j, cj, c) in itertools.product(
         range(nsrc), range(nchan), range(nchan)
@@ -491,56 +587,34 @@ def _project(reference_sources, C):
         sproj[c] += fftconvolve(
             C[j, cj, :, c],
             reference_sources[j, :, cj]
-        )[:nsampl + flen - 1]
+        )[:nsampl + filters_len - 1]
     return sproj.T
 
 
-def _wsum(sig, window, hop, flen, axis=0):
-    """ computes a sum on windowed versions of the signal"""
-    if window >= sig.shape[axis] - flen:
-        res = np.empty((1,))
-        res[0] = np.sum(sig)
-        return res
-
-    sig = np.moveaxis(sig, axis, 0)
-    length = sig.shape[0]
-    nwin = int(np.floor((length - flen + 1 - window + hop) / hop))
-    new_shape = np.array(sig.shape)
-    new_shape[0] = nwin
-    res = np.empty((nwin,))
-    for k in range(nwin):
-        if k < nwin:
-            win_slice = slice(k * hop, min(length, k * hop + window))
-        else:
-            win_slice = slice(k * hop, length)
-        res[k, ...] = np.sum(sig[win_slice, ...])
-    res = np.moveaxis(res, 0, axis)
-    return res
-
-
-def _bss_crit(s_true, e_spat, e_interf, e_artif,
-              window, hop, flen, bsseval_sources):
+def _bss_crit(s_true, e_spat, e_interf, e_artif,bsseval_sources_version):
     """Measurement of the separation quality for a given source in terms of
     filtered true source, interference and artifacts.
-    windowed version
+
     """
     # energy ratios
-    energy_s_filt = _wsum((s_true + e_spat)**2, window, hop, flen)
-    if bsseval_sources:
+    if bsseval_sources_version:
+        s_filt = s_true + e_spat
+        energy_s_filt = np.sum(s_filt**2)
         sdr = _safe_db(energy_s_filt,
-                       _wsum((e_interf + e_artif)**2, window, hop, flen))
+                       np.sum((e_interf + e_artif)**2))
         isr = np.empty(sdr.shape) * np.nan
+        sir = _safe_db(energy_s_filt, np.sum(e_interf**2))
+        sar = _safe_db(np.sum((s_filt + e_interf)**2),
+                       np.sum(e_artif**2))
     else:
-        energy_s_true = _wsum((s_true)**2, window, hop, flen)
+        energy_s_true = np.sum((s_true)**2)
         sdr = _safe_db(energy_s_true,
-                       _wsum(
-                        (e_spat + e_interf + e_artif)**2, window, hop, flen)
-                       )
-        isr = _safe_db(energy_s_true, _wsum(e_spat**2, window, hop, flen))
+                       np.sum((e_spat + e_interf + e_artif)**2))
+        isr = _safe_db(energy_s_true, np.sum(e_spat**2))
+        sir = _safe_db(np.sum((s_true + e_spat)**2) , np.sum(e_interf**2))
+        sar = _safe_db(np.sum((s_true + e_spat + e_interf)**2) ,
+            np.sum(e_artif**2))
 
-    sir = _safe_db(energy_s_filt, _wsum(e_interf**2, window, hop, flen))
-    sar = _safe_db(_wsum((s_true + e_spat + e_interf)**2, window, hop, flen),
-                   _wsum(e_artif**2, window, hop, flen))
     return (sdr, isr, sir, sar)
 
 
@@ -548,21 +622,17 @@ def _safe_db(num, den):
     """Properly handle the potential +Inf db SIR instead of raising a
     RuntimeWarning.
     """
-    indices = np.nonzero(den)
-    res = np.empty_like(num)
-    res[:] = np.inf
-    res[indices] = 10 * np.log10(num[indices] / den[indices])
-    return res
-
+    if den == 0:
+        return np.inf
+    else:
+        return 10 * np.log10(num / den)
 
 def evaluate(reference_sources, estimated_sources, **kwargs):
     """Compute all metrics for the given reference and estimated signals.
-
     NOTE: This will always compute :func:`mir_eval.separation.bss_eval_images`
     for any valid input and will additionally compute
     :func:`mir_eval.separation.bss_eval_sources` for valid input with fewer
     than 3 dimensions.
-
     Examples
     --------
     >>> # reference_sources[n] should be an ndarray of samples of the
@@ -570,7 +640,6 @@ def evaluate(reference_sources, estimated_sources, **kwargs):
     >>> # estimated_sources[n] should be the same for the n'th estimated source
     >>> scores = mir_eval.separation.evaluate(reference_sources,
     ...                                       estimated_sources)
-
     Parameters
     ----------
     reference_sources : np.ndarray, shape=(nsrc, nsampl[, nchan])
@@ -580,13 +649,11 @@ def evaluate(reference_sources, estimated_sources, **kwargs):
     kwargs
         Additional keyword arguments which will be passed to the
         appropriate metric or preprocessing functions.
-
     Returns
     -------
     scores : dict
         Dictionary of scores, where the key is the metric name (str) and
         the value is the (float) score achieved.
-
     """
     # Compute all the metrics
     scores = collections.OrderedDict()

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -579,7 +579,7 @@ def _compute_projection_filters(G, sf, estimated_source):
 
     # Distortion filters
     try:
-        C = np.linalg.solve(G + eps*np.eye(nsrc), D).reshape(
+        C = np.linalg.solve(G + eps*np.eye(G.shape[0]), D).reshape(
             nsrc, nchan, filters_len, nchan, order='F'
         )
     except np.linalg.linalg.LinAlgError:

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -247,15 +247,15 @@ def bss_eval(reference_sources, estimated_sources,
     # defines all the permutations desired by user
     if compute_permutation:
         candidate_permutations = np.array(list(
-            itertools.permutations(range(nsrc))))
+            itertools.permutations(list(range(nsrc)))))
     else:
-        candidate_permutations = np.array(range(nsrc))[None, :]
+        candidate_permutations = np.array(np.arange(nsrc))[None, :]
 
     # initialize variables
     framer = Framing(window, hop, nsampl)
     nwin = framer.nwin
 
-    (SDR, ISR, SIR, SAR) = range(4)
+    (SDR, ISR, SIR, SAR) = list(range(4))
     s_r = np.empty((4, nsrc, nsrc, nwin))
 
     # define helper functions for computing filters on windows of the signals
@@ -336,7 +336,7 @@ def bss_eval(reference_sources, estimated_sources,
         result = s_r[:, dum, popt[:, 0], :]
     else:
         result = np.empty((4, nsrc, nwin))
-        for (m, t) in itertools.product(range(4), range(nwin)):
+        for (m, t) in itertools.product(list(range(4)), list(range(nwin))):
             result[m, :, t] = s_r[m, dum, popt[:, t], t]
 
     return (result[SDR], result[ISR], result[SIR], result[SAR], popt)
@@ -521,7 +521,11 @@ def _compute_reference_correlations(reference_sources, filters_len):
     # compute intercorrelation between sources
     G = np.zeros((nsrc, nsrc, nchan, nchan, filters_len, filters_len))
     for ((i, c1), (j, c2)) in itertools.combinations_with_replacement(
-                           itertools.product(range(nsrc), range(nchan)), 2):
+        itertools.product(
+            list(range(nsrc)), list(range(nchan))
+        ),
+        2
+    ):
 
         ssf = sf[j, c2] * np.conj(sf[i, c1])
         ssf = np.real(scipy.fftpack.ifft(ssf))
@@ -560,7 +564,7 @@ def _compute_projection_filters(G, sf, estimated_source):
     # compute the cross-correlations between sources and estimates
     D = np.zeros((nsrc, nchan, filters_len, nchan))
     for (j, cj, c) in itertools.product(
-        range(nsrc), range(nchan), range(nchan)
+        list(range(nsrc)), list(range(nchan)), list(range(nchan))
     ):
         ssef = sf[j, cj] * np.conj(sef[c])
         ssef = np.real(scipy.fftpack.ifft(ssef))
@@ -605,7 +609,7 @@ def _project(reference_sources, C):
     sproj = np.zeros((nchan, nsampl + filters_len - 1))
 
     for (j, cj, c) in itertools.product(
-        range(nsrc), range(nchan), range(nchan)
+        list(range(nsrc)), list(range(nchan)), list(range(nchan))
     ):
         sproj[c] += fftconvolve(
             C[j, cj, :, c],

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -29,9 +29,10 @@ Metrics
   ratios, plus the image to spatial ratio (ISR). These are computed on a frame
   by frame basis, (with infinite window size meaning the whole signal).
 
-  Optionally, the distortion filters are time-varying, corresponding to behavior
-  of BSS Eval version 3. Furthermore, metrics may optionally correspond to the
-  bsseval_sources version, as defined in the BSS Eval version 2.
+  Optionally, the distortion filters are time-varying, corresponding to
+  behavior of BSS Eval version 3. Furthermore, metrics may optionally
+  correspond to the bsseval_sources version, as defined in the BSS Eval
+  version 2.
 
 References
 ----------
@@ -88,8 +89,8 @@ def validate(reference_sources, estimated_sources):
 
     if reference_sources.size == 0:
         warnings.warn("reference_sources is empty, should be of size "
-                      "(nsrc, nsample, nchan). sdr, isr sir, sar, and perm will"
-                      " all be empty np.ndarrays")
+                      "(nsrc, nsample, nchan). sdr, isr sir, sar, and perm "
+                      "will all be empty np.ndarrays")
     elif _any_source_silent(reference_sources):
         raise ValueError('All the reference sources should be non-silent (not '
                          'all-zeros), but at least one of the reference '
@@ -207,8 +208,8 @@ def bss_eval(reference_sources, estimated_sources,
         matrix of Sources to Artifacts Ratios (SAR)
     perm : np.ndarray, shape=(nsrc, nwin)
         vector containing the best ordering of estimated sources in
-        the mean SIR sense (estimated source number ``perm[j,t]`` corresponds to
-        true source number ``j`` at window ``t``).
+        the mean SIR sense (estimated source number ``perm[j,t]`` corresponds
+        to true source number ``j`` at window ``t``).
         Note: ``perm`` will be ``(0,2,...,nsrc-1)`` if ``compute_permutation``
         is ``False``.
 
@@ -519,7 +520,6 @@ def _compute_reference_correlations(reference_sources, filters_len):
     G = np.zeros((nsrc, nsrc, nchan, nchan, filters_len, filters_len))
     for ((i, c1), (j, c2)) in itertools.combinations_with_replacement(
                            itertools.product(range(nsrc), range(nchan)), 2):
-    # for ((i, c1, j, c2)) in itertools.product(*(range(nsrc), range(nchan)) * 2):
 
         ssf = sf[j, c2] * np.conj(sf[i, c1])
         ssf = np.real(scipy.fftpack.ifft(ssf))
@@ -534,7 +534,8 @@ def _compute_reference_correlations(reference_sources, filters_len):
 
 def _compute_projection_filters(G, sf, estimated_source):
     """Least-squares projection of estimated source on the subspace spanned by
-    delayed versions of reference sources, with delays between 0 and filters_len-1
+    delayed versions of reference sources, with delays between 0 and
+    filters_len-1
     """
     # shapes
     (nsampl, nchan) = estimated_source.shape

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -11,30 +11,25 @@ See also the bss_eval MATLAB toolbox:
 Conventions
 -----------
 
-An audio signal is expected to be in the format of a 1-dimensional array where
-the entries are the samples of the audio signal.  When providing a group of
-estimated or reference sources, they should be provided in a 2-dimensional
-array, where the first dimension corresponds to the source number and the
-second corresponds to the samples.
+An audio signal is expected to be in the format of a 2-dimensional array where
+the first dimension goes over the samples of the audio signal and the second
+dimension goes over the channels (as in stereo left and right).
+When providing a group of estimated or reference sources, they should be
+provided in a 3-dimensional array, where the first dimension corresponds to the
+source number, the second corresponds to the samples and the third to the
+channels.
 
 Metrics
 -------
 
-* :func:`mir_eval.separation.bss_eval_sources`: Computes the bss_eval_sources
-  metrics from bss_eval, which optionally optimally match the estimated sources
-  to the reference sources and measure the distortion and artifacts present in
-  the estimated sources as well as the interference between them.
-
-* :func:`mir_eval.separation.bss_eval_sources_framewise`: Computes the
-  bss_eval_sources metrics on a frame-by-frame basis.
-
-* :func:`mir_eval.separation.bss_eval_images`: Computes the bss_eval_images
-  metrics from bss_eval, which includes the metrics in
-  :func:`mir_eval.separation.bss_eval_sources` plus the image to spatial
-  distortion ratio.
-
-* :func:`mir_eval.separation.bss_eval_images_framewise`: Computes the
-  bss_eval_images metrics on a frame-by-frame basis.
+* :func:`mir_eval.separation.bss_eval`: Computes the bss_eval metrics from
+  bss_eval. First, it matches the estimated sources to the references through
+  time-invariant filters. Then, it computes the source to distortion (SDR),
+  source to artifacts (SAR), source to interference (SIR) ratios, plus the image
+  to spatial ratio (ISR) for multichannel signals.
+  These are computed on a frame by frame basis, (with infinite window size
+  meaning the whole signal). Metrics correspond to the bsseval_images version,
+  but may optionally correspond to the (deprecated) bsseval_sources version.
 
 References
 ----------
@@ -42,22 +37,19 @@ References
       Févotte, "Performance measurement in blind audio source separation," IEEE
       Trans. on Audio, Speech and Language Processing, 14(4):1462-1469, 2006.
 
-
 '''
 
 import numpy as np
 import scipy.fftpack
 from scipy.linalg import toeplitz
 from scipy.signal import fftconvolve
-import collections
 import itertools
+import collections
 import warnings
 from . import util
 
-
 # The maximum allowable number of sources (prevents insane computational load)
 MAX_SOURCES = 100
-
 
 def validate(reference_sources, estimated_sources):
     """Checks that the input data to a metric are valid, and throws helpful
@@ -65,9 +57,9 @@ def validate(reference_sources, estimated_sources):
 
     Parameters
     ----------
-    reference_sources : np.ndarray, shape=(nsrc, nsampl)
+    reference_sources : np.ndarray, shape=(nsrc, nsampl,nchan)
         matrix containing true sources
-    estimated_sources : np.ndarray, shape=(nsrc, nsampl)
+    estimated_sources : np.ndarray, shape=(nsrc, nsampl,nchan)
         matrix containing estimated sources
 
     """
@@ -88,8 +80,8 @@ def validate(reference_sources, estimated_sources):
 
     if reference_sources.size == 0:
         warnings.warn("reference_sources is empty, should be of size "
-                      "(nsrc, nsample).  sdr, sir, sar, and perm will all "
-                      "be empty np.ndarrays")
+                      "(nsrc, nsample, nchan). sdr, sir, sar, and perm will all"
+                      " be empty np.ndarrays")
     elif _any_source_silent(reference_sources):
         raise ValueError('All the reference sources should be non-silent (not '
                          'all-zeros), but at least one of the reference '
@@ -99,8 +91,8 @@ def validate(reference_sources, estimated_sources):
 
     if estimated_sources.size == 0:
         warnings.warn("estimated_sources is empty, should be of size "
-                      "(nsrc, nsample).  sdr, sir, sar, and perm will all "
-                      "be empty np.ndarrays")
+                      "(nsrc, nsample, nchan).  sdr, sir, sar, and perm will "
+                      "all be empty np.ndarrays")
     elif _any_source_silent(estimated_sources):
         raise ValueError('All the estimated sources should be non-silent (not '
                          'all-zeros), but at least one of the estimated '
@@ -111,272 +103,48 @@ def validate(reference_sources, estimated_sources):
     if (estimated_sources.shape[0] > MAX_SOURCES or
             reference_sources.shape[0] > MAX_SOURCES):
         raise ValueError('The supplied matrices should be of shape (nsrc,'
-                         ' nsampl) but reference_sources.shape[0] = {} and '
-                         'estimated_sources.shape[0] = {} which is greater '
+                         ' nsampl, nchan) but reference_sources.shape[0] = {} '
+                         'and estimated_sources.shape[0] = {} which is greater '
                          'than mir_eval.separation.MAX_SOURCES = {}.  To '
                          'override this check, set '
                          'mir_eval.separation.MAX_SOURCES to a '
                          'larger value.'.format(reference_sources.shape[0],
                                                 estimated_sources.shape[0],
                                                 MAX_SOURCES))
-
-
 def _any_source_silent(sources):
     """Returns true if the parameter sources has any silent first dimensions"""
     return np.any(np.all(np.sum(
         sources, axis=tuple(range(2, sources.ndim))) == 0, axis=1))
 
+def bss_eval(reference_sources, estimated_sources,
+                    window = 2*44100, hop = 1.5*44100,
+                    compute_permutation = False,
+                    flen = 512,
+                    bsseval_sources = False):
+    """Implementation of the bss_eval function, adapted from the
+    BSS_EVAL Matlab toolbox and mir_eval.separation.
 
-def bss_eval_sources(reference_sources, estimated_sources,
-                     compute_permutation=True):
-    """
-    Ordering and measurement of the separation quality for estimated source
-    signals in terms of filtered true source, interference and artifacts.
-
-    The decomposition allows a time-invariant filter distortion of length
-    512, as described in Section III.B of [#vincent2006performance]_.
-
-    Passing ``False`` for ``compute_permutation`` will improve the computation
-    performance of the evaluation; however, it is not always appropriate and
-    is not the way that the BSS_EVAL Matlab toolbox computes bss_eval_sources.
-
-    Examples
-    --------
-    >>> # reference_sources[n] should be an ndarray of samples of the
-    >>> # n'th reference source
-    >>> # estimated_sources[n] should be the same for the n'th estimated
-    >>> # source
-    >>> (sdr, sir, sar,
-    ...  perm) = mir_eval.separation.bss_eval_sources(reference_sources,
-    ...                                               estimated_sources)
-
-    Parameters
-    ----------
-    reference_sources : np.ndarray, shape=(nsrc, nsampl)
-        matrix containing true sources (must have same shape as
-        estimated_sources)
-    estimated_sources : np.ndarray, shape=(nsrc, nsampl)
-        matrix containing estimated sources (must have same shape as
-        reference_sources)
-    compute_permutation : bool, optional
-        compute permutation of estimate/source combinations (True by default)
-
-    Returns
-    -------
-    sdr : np.ndarray, shape=(nsrc,)
-        vector of Signal to Distortion Ratios (SDR)
-    sir : np.ndarray, shape=(nsrc,)
-        vector of Source to Interference Ratios (SIR)
-    sar : np.ndarray, shape=(nsrc,)
-        vector of Sources to Artifacts Ratios (SAR)
-    perm : np.ndarray, shape=(nsrc,)
-        vector containing the best ordering of estimated sources in
-        the mean SIR sense (estimated source number ``perm[j]`` corresponds to
-        true source number ``j``). Note: ``perm`` will be ``[0, 1, ...,
-        nsrc-1]`` if ``compute_permutation`` is ``False``.
-
-    References
-    ----------
-    .. [#] Emmanuel Vincent, Shoko Araki, Fabian J. Theis, Guido Nolte, Pau
-        Bofill, Hiroshi Sawada, Alexey Ozerov, B. Vikrham Gowreesunker, Dominik
-        Lutter and Ngoc Q.K. Duong, "The Signal Separation Evaluation Campaign
-        (2007-2010): Achievements and remaining challenges", Signal Processing,
-        92, pp. 1928-1936, 2012.
-
-    """
-
-    # make sure the input is of shape (nsrc, nsampl)
-    if estimated_sources.ndim == 1:
-        estimated_sources = estimated_sources[np.newaxis, :]
-    if reference_sources.ndim == 1:
-        reference_sources = reference_sources[np.newaxis, :]
-
-    validate(reference_sources, estimated_sources)
-    # If empty matrices were supplied, return empty lists (special case)
-    if reference_sources.size == 0 or estimated_sources.size == 0:
-        return np.array([]), np.array([]), np.array([]), np.array([])
-
-    nsrc = estimated_sources.shape[0]
-
-    # does user desire permutations?
-    if compute_permutation:
-        # compute criteria for all possible pair matches
-        sdr = np.empty((nsrc, nsrc))
-        sir = np.empty((nsrc, nsrc))
-        sar = np.empty((nsrc, nsrc))
-        for jest in range(nsrc):
-            for jtrue in range(nsrc):
-                s_true, e_spat, e_interf, e_artif = \
-                    _bss_decomp_mtifilt(reference_sources,
-                                        estimated_sources[jest],
-                                        jtrue, 512)
-                sdr[jest, jtrue], sir[jest, jtrue], sar[jest, jtrue] = \
-                    _bss_source_crit(s_true, e_spat, e_interf, e_artif)
-
-        # select the best ordering
-        perms = list(itertools.permutations(list(range(nsrc))))
-        mean_sir = np.empty(len(perms))
-        dum = np.arange(nsrc)
-        for (i, perm) in enumerate(perms):
-            mean_sir[i] = np.mean(sir[perm, dum])
-        popt = perms[np.argmax(mean_sir)]
-        idx = (popt, dum)
-        return (sdr[idx], sir[idx], sar[idx], np.asarray(popt))
-    else:
-        # compute criteria for only the simple correspondence
-        # (estimate 1 is estimate corresponding to reference source 1, etc.)
-        sdr = np.empty(nsrc)
-        sir = np.empty(nsrc)
-        sar = np.empty(nsrc)
-        for j in range(nsrc):
-            s_true, e_spat, e_interf, e_artif = \
-                _bss_decomp_mtifilt(reference_sources,
-                                    estimated_sources[j],
-                                    j, 512)
-            sdr[j], sir[j], sar[j] = \
-                _bss_source_crit(s_true, e_spat, e_interf, e_artif)
-
-        # return the default permutation for compatibility
-        popt = np.arange(nsrc)
-        return (sdr, sir, sar, popt)
-
-
-def bss_eval_sources_framewise(reference_sources, estimated_sources,
-                               window=30*44100, hop=15*44100,
-                               compute_permutation=False):
-    """Framewise computation of bss_eval_sources
-
-    Please be aware that this function does not compute permutations (by
-    default) on the possible relations between reference_sources and
-    estimated_sources due to the dangers of a changing permutation. Therefore
-    (by default), it assumes that ``reference_sources[i]`` corresponds to
-    ``estimated_sources[i]``. To enable computing permutations please set
-    ``compute_permutation`` to be ``True`` and check that the returned ``perm``
-    is identical for all windows.
-
-    NOTE: if ``reference_sources`` and ``estimated_sources`` would be evaluated
-    using only a single window or are shorter than the window length, the
-    result of :func:`mir_eval.separation.bss_eval_sources` called on
-    ``reference_sources`` and ``estimated_sources`` (with the
-    ``compute_permutation`` parameter passed to
-    :func:`mir_eval.separation.bss_eval_sources`) is returned.
-
-    Examples
-    --------
-    >>> # reference_sources[n] should be an ndarray of samples of the
-    >>> # n'th reference source
-    >>> # estimated_sources[n] should be the same for the n'th estimated
-    >>> # source
-    >>> (sdr, sir, sar,
-    ...  perm) = mir_eval.separation.bss_eval_sources_framewise(
-             reference_sources,
-    ...      estimated_sources)
-
-    Parameters
-    ----------
-    reference_sources : np.ndarray, shape=(nsrc, nsampl)
-        matrix containing true sources (must have the same shape as
-        ``estimated_sources``)
-    estimated_sources : np.ndarray, shape=(nsrc, nsampl)
-        matrix containing estimated sources (must have the same shape as
-        ``reference_sources``)
-    window : int, optional
-        Window length for framewise evaluation (default value is 30s at a
-        sample rate of 44.1kHz)
-    hop : int, optional
-        Hop size for framewise evaluation (default value is 15s at a
-        sample rate of 44.1kHz)
-    compute_permutation : bool, optional
-        compute permutation of estimate/source combinations for all windows
-        (False by default)
-
-    Returns
-    -------
-    sdr : np.ndarray, shape=(nsrc, nframes)
-        vector of Signal to Distortion Ratios (SDR)
-    sir : np.ndarray, shape=(nsrc, nframes)
-        vector of Source to Interference Ratios (SIR)
-    sar : np.ndarray, shape=(nsrc, nframes)
-        vector of Sources to Artifacts Ratios (SAR)
-    perm : np.ndarray, shape=(nsrc, nframes)
-        vector containing the best ordering of estimated sources in
-        the mean SIR sense (estimated source number ``perm[j]`` corresponds to
-        true source number ``j``).  Note: ``perm`` will be ``range(nsrc)`` for
-        all windows if ``compute_permutation`` is ``False``
-
-    """
-
-    # make sure the input is of shape (nsrc, nsampl)
-    if estimated_sources.ndim == 1:
-        estimated_sources = estimated_sources[np.newaxis, :]
-    if reference_sources.ndim == 1:
-        reference_sources = reference_sources[np.newaxis, :]
-
-    validate(reference_sources, estimated_sources)
-    # If empty matrices were supplied, return empty lists (special case)
-    if reference_sources.size == 0 or estimated_sources.size == 0:
-        return np.array([]), np.array([]), np.array([]), np.array([])
-
-    nsrc = reference_sources.shape[0]
-
-    nwin = int(
-        np.floor((reference_sources.shape[1] - window + hop) / hop)
-    )
-    # if fewer than 2 windows would be evaluated, return the sources result
-    if nwin < 2:
-        result = bss_eval_sources(reference_sources,
-                                  estimated_sources,
-                                  compute_permutation)
-        return [np.expand_dims(score, -1) for score in result]
-
-    # compute the criteria across all windows
-    sdr = np.empty((nsrc, nwin))
-    sir = np.empty((nsrc, nwin))
-    sar = np.empty((nsrc, nwin))
-    perm = np.empty((nsrc, nwin))
-
-    # k iterates across all the windows
-    for k in range(nwin):
-        win_slice = slice(k * hop, k * hop + window)
-        ref_slice = reference_sources[:, win_slice]
-        est_slice = estimated_sources[:, win_slice]
-        # check for a silent frame
-        if (not _any_source_silent(ref_slice) and
-                not _any_source_silent(est_slice)):
-            sdr[:, k], sir[:, k], sar[:, k], perm[:, k] = bss_eval_sources(
-                ref_slice, est_slice, compute_permutation
-            )
-        else:
-            # if we have a silent frame set results as np.nan
-            sdr[:, k] = sir[:, k] = sar[:, k] = perm[:, k] = np.nan
-
-    return sdr, sir, sar, perm
-
-
-def bss_eval_images(reference_sources, estimated_sources,
-                    compute_permutation=True):
-    """Implementation of the bss_eval_images function from the
-    BSS_EVAL Matlab toolbox.
-
-    Ordering and measurement of the separation quality for estimated source
-    signals in terms of filtered true source, interference and artifacts.
-    This method also provides the ISR measure.
+    Measurement of the separation quality for estimated source signals
+    in terms of filtered true source, interference and artifacts.
+    This method also provides the ISR measure for multichannel signals.
 
     The decomposition allows a time-invariant filter distortion of length
-    512, as described in Section III.B of [#vincent2006performance]_.
+    flen=512, as described in Section III.B of [#vincent2006performance]_, and
+    computes the metrics on a windowed basis.
 
-    Passing ``False`` for ``compute_permutation`` will improve the computation
-    performance of the evaluation; however, it is not always appropriate and
-    is not the way that the BSS_EVAL Matlab toolbox computes bss_eval_images.
+    Passing ``False`` for ``compute_permutation`` will assume the order for
+    the estimated sources matches that of the true sources. Otherwise, all
+    permutations are tested, yielding a significant computation overhead.
+
 
     Examples
     --------
-    >>> # reference_sources[n] should be an ndarray of samples of the
-    >>> # n'th reference source
+    >>> # reference_sources[n] should be a 2D ndarray, with first dimension the
+    >>> # samples and second dimension the channels of the n'th reference source
     >>> # estimated_sources[n] should be the same for the n'th estimated
     >>> # source
     >>> (sdr, isr, sir, sar,
-    ...  perm) = mir_eval.separation.bss_eval_images(reference_sources,
+    ...  perm) = mir_eval.separation.bss_eval(reference_sources,
     ...                                               estimated_sources)
 
     Parameters
@@ -385,20 +153,33 @@ def bss_eval_images(reference_sources, estimated_sources,
         matrix containing true sources
     estimated_sources : np.ndarray, shape=(nsrc, nsampl, nchan)
         matrix containing estimated sources
+    window : int, optional
+        size of each window for time-varying evaluation. Picking np.inf will
+        compute on the whole signal.
+    hop : int, optional
+        hop size between windows
     compute_permutation : bool, optional
         compute permutation of estimate/source combinations (True by default)
-
+    bsseval_sources : bool, optional
+        if  ``True``, results correspond to :func:`bss_eval_sources` from
+        the BSS Eval. Note however that this is not recommended because this
+        evaluation method amounts to modify the references according to the
+        estimated sources, leading to potential problems. For instance, zeroing
+        some frequencies in the estimates will lead those to also be zeroed in
+        the references, and hence not evaluated, artificially boosting results.
+        For this reason, SiSEC always uses the :func:`bss_eval_images` version.
     Returns
     -------
-    sdr : np.ndarray, shape=(nsrc,)
-        vector of Signal to Distortion Ratios (SDR)
-    isr : np.ndarray, shape=(nsrc,)
-        vector of source Image to Spatial distortion Ratios (ISR)
-    sir : np.ndarray, shape=(nsrc,)
-        vector of Source to Interference Ratios (SIR)
-    sar : np.ndarray, shape=(nsrc,)
-        vector of Sources to Artifacts Ratios (SAR)
-    perm : np.ndarray, shape=(nsrc,)
+    sdr : np.ndarray, shape=(nsrc, nwin)
+        matrix of Signal to Distortion Ratios (SDR). One for each source and
+        window
+    isr : np.ndarray, shape=(nsrc, nwin)
+        matrix of source Image to Spatial distortion Ratios (ISR)
+    sir : np.ndarray, shape=(nsrc, nwin)
+        matrix of Source to Interference Ratios (SIR)
+    sar : np.ndarray, shape=(nsrc, nwin)
+        matrix of Sources to Artifacts Ratios (SAR)
+    perm : np.ndarray, shape=(nsrc, nwin)
         vector containing the best ordering of estimated sources in
         the mean SIR sense (estimated source number ``perm[j]`` corresponds to
         true source number ``j``).  Note: ``perm`` will be ``(1,2,...,nsrc)``
@@ -413,426 +194,330 @@ def bss_eval_images(reference_sources, estimated_sources,
         92, pp. 1928-1936, 2012.
 
     """
+    # make sure the input is at least of shape (nsrc, nsampl) if only single
+    # channel samples were provided.
+    if estimated_sources.ndim == 1:
+        estimated_sources = estimated_sources[None, :]
+    if reference_sources.ndim == 1:
+        reference_sources = reference_sources[None, :]
 
     # make sure the input has 3 dimensions
     # assuming input is in shape (nsampl) or (nsrc, nsampl)
     estimated_sources = np.atleast_3d(estimated_sources)
     reference_sources = np.atleast_3d(reference_sources)
-    # we will ensure input doesn't have more than 3 dimensions in validate
 
+    #validate input
     validate(reference_sources, estimated_sources)
+
     # If empty matrices were supplied, return empty lists (special case)
     if reference_sources.size == 0 or estimated_sources.size == 0:
-        return np.array([]), np.array([]), np.array([]), \
-                         np.array([]), np.array([])
+        return (np.array([]), np.array([]), np.array([]), np.array([]),
+            np.array([]))
 
     # determine size parameters
-    nsrc = estimated_sources.shape[0]
-    nsampl = estimated_sources.shape[1]
-    nchan = estimated_sources.shape[2]
+    (nsrc, nsampl, nchan) = estimated_sources.shape
 
-    # does the user desire permutation?
+    #First compute the time-invariant distortion filters from all refs
+    #to each source
+    G,sf = _compute_reference_correlations(reference_sources, flen)
+    C  = np.zeros((nsrc,nsrc,nchan,flen,nchan))
+    for src in range(nsrc):
+        C[src] = _compute_projection_filters(G, sf, estimated_sources[src])
+
+    # defines all the permutations desired by user
     if compute_permutation:
-        # compute criteria for all possible pair matches
-        sdr = np.empty((nsrc, nsrc))
-        isr = np.empty((nsrc, nsrc))
-        sir = np.empty((nsrc, nsrc))
-        sar = np.empty((nsrc, nsrc))
-        for jest in range(nsrc):
-            for jtrue in range(nsrc):
-                s_true, e_spat, e_interf, e_artif = \
-                    _bss_decomp_mtifilt_images(
-                        reference_sources,
-                        np.reshape(
-                            estimated_sources[jest],
-                            (nsampl, nchan),
-                            order='F'
-                        ),
-                        jtrue,
-                        512
-                    )
-                sdr[jest, jtrue], isr[jest, jtrue], \
-                    sir[jest, jtrue], sar[jest, jtrue] = \
-                    _bss_image_crit(s_true, e_spat, e_interf, e_artif)
-
-        # select the best ordering
-        perms = list(itertools.permutations(range(nsrc)))
-        mean_sir = np.empty(len(perms))
-        dum = np.arange(nsrc)
-        for (i, perm) in enumerate(perms):
-            mean_sir[i] = np.mean(sir[perm, dum])
-        popt = perms[np.argmax(mean_sir)]
-        idx = (popt, dum)
-        return (sdr[idx], isr[idx], sir[idx], sar[idx], np.asarray(popt))
+        candidate_permutations = np.array(list(
+                    itertools.permutations(range(nsrc))))
     else:
-        # compute criteria for only the simple correspondence
-        # (estimate 1 is estimate corresponding to reference source 1, etc.)
-        sdr = np.empty(nsrc)
-        isr = np.empty(nsrc)
-        sir = np.empty(nsrc)
-        sar = np.empty(nsrc)
-        Gj = [0] * nsrc  # prepare G matrics with zeroes
-        G = np.zeros(1)
-        for j in range(nsrc):
-            # save G matrix to avoid recomputing it every call
-            s_true, e_spat, e_interf, e_artif, Gj_temp, G = \
-                _bss_decomp_mtifilt_images(reference_sources,
-                                           np.reshape(estimated_sources[j],
-                                                      (nsampl, nchan),
-                                                      order='F'),
-                                           j, 512, Gj[j], G)
-            Gj[j] = Gj_temp
-            sdr[j], isr[j], sir[j], sar[j] = \
-                _bss_image_crit(s_true, e_spat, e_interf, e_artif)
+        candidate_permutations = np.array(range(nsrc))[None,:]
 
-        # return the default permutation for compatibility
-        popt = np.arange(nsrc)
-        return (sdr, isr, sir, sar, popt)
+    # prepare criteria variable for all possible pair matches and
+    # initialize variables
+    if window < nsampl:
+        nwin = int(
+            np.floor((reference_sources.shape[1] - window + hop) / hop)
+            )
+    else:
+        nwin = 1
+    print('number of windows:',nwin,'number of sources', nsrc)
+    (SDR,ISR,SIR,SAR)=range(4)
+    s_r = np.empty((4,nsrc,nsrc,nwin))
+    done = np.zeros((nsrc,nsrc))
+    #print(nsrc)
+    for jtrue in range(nsrc):
+        for (k,jest) in enumerate(candidate_permutations[:,jtrue]):
+            #print(jtrue,jest,done)
+            if not done[jest,jtrue]:
+                #need to compute the scores for this combination
+                Cj = _compute_projection_filters(G[jtrue, jtrue], sf[jtrue],
+                                        estimated_sources[jest])
+                s_true, e_spat, e_interf, e_artif = \
+                    _bss_decomp_mtifilt(
+                        reference_sources,
+                        estimated_sources[jest], jtrue, C[jest], Cj)
+                (a,b,c,d)= _bss_crit(s_true, e_spat, e_interf,
+                    e_artif, window, hop, flen,bsseval_sources)
+                print(jtrue,jest,a,b,c,d,'SDR,ISR,SIR,SAR', window, hop)
+                s_r[:,jest, jtrue,:] = np.array((a,b,c,d))
+                #_bss_crit(s_true, e_spat, e_interf,
+                #    e_artif, window, hop, bsseval_sources)
+                done[jest,jtrue]=True
 
+    # select the best ordering
+    mean_sir = np.empty(len(candidate_permutations))
+    dum = np.arange(nsrc)
+    for (i, perm) in enumerate(candidate_permutations):
+        mean_sir[i] = np.mean(s_r[SIR,perm, dum,:])
+    popt = candidate_permutations[np.argmax(mean_sir)]
+    idx = (popt, dum)
+
+    return [np.squeeze(s_r[x,popt,dum,:]) for x in (SDR,ISR,SIR,SAR) ]+ [popt,]
+    #return [np.squeeze(x) for x in s_r[:,popt,dum,:]] + [ popt,]
+
+def bss_eval_sources(reference_sources, estimated_sources,
+                     compute_permutation=True):
+    """
+    Wrapper to ``bss_eval`` with the right parameters.
+    The call to this function is not recommended. See the description for the
+    ``bsseval_sources`` parameter of ``bss_eval``.
+
+    """
+    (sdr, isr,sir,sar,perm) = \
+        bss_eval(reference_sources, estimated_sources,
+                    window = np.inf, hop = np.inf,
+                    compute_permutation = compute_permutation, flen = 512,
+                    bsseval_sources = True)
+    return (sdr, sir, sar, perm)
+
+def bss_eval_sources_framewise(reference_sources, estimated_sources,
+                               window=30*44100, hop=15*44100,
+                               compute_permutation=False):
+    """
+    Wrapper to ``bss_eval`` with the right parameters.
+    The call to this function is not recommended. See the description for the
+    ``bsseval_sources`` parameter of ``bss_eval``.
+
+    """
+    (sdr, isr,sir,sar,perm) = \
+        bss_eval(reference_sources, estimated_sources,
+                    window = window, hop = hop,
+                    compute_permutation = compute_permutation, flen = 512,
+                    bsseval_sources = True)
+    return (sdr, sir, sar, perm)
+
+def bss_eval_images(reference_sources, estimated_sources,
+                    compute_permutation=True):
+    """
+    Wrapper to ``bss_eval`` with the right parameters.
+
+    """
+    return bss_eval(reference_sources, estimated_sources,
+                    window = np.inf, hop = np.inf,
+                    compute_permutation = compute_permutation, flen = 512,
+                    bsseval_sources = False)
 
 def bss_eval_images_framewise(reference_sources, estimated_sources,
                               window=30*44100, hop=15*44100,
                               compute_permutation=False):
-    """Framewise computation of bss_eval_images
-
-    Please be aware that this function does not compute permutations (by
-    default) on the possible relations between ``reference_sources`` and
-    ``estimated_sources`` due to the dangers of a changing permutation.
-    Therefore (by default), it assumes that ``reference_sources[i]``
-    corresponds to ``estimated_sources[i]``. To enable computing permutations
-    please set ``compute_permutation`` to be ``True`` and check that the
-    returned ``perm`` is identical for all windows.
-
-    NOTE: if ``reference_sources`` and ``estimated_sources`` would be evaluated
-    using only a single window or are shorter than the window length, the
-    result of ``bss_eval_images`` called on ``reference_sources`` and
-    ``estimated_sources`` (with the ``compute_permutation`` parameter passed to
-    ``bss_eval_images``) is returned
-
-    Examples
-    --------
-    >>> # reference_sources[n] should be an ndarray of samples of the
-    >>> # n'th reference source
-    >>> # estimated_sources[n] should be the same for the n'th estimated
-    >>> # source
-    >>> (sdr, isr, sir, sar,
-    ...  perm) = mir_eval.separation.bss_eval_images_framewise(
-             reference_sources,
-    ...      estimated_sources,
-             window,
-    ....     hop)
-
-    Parameters
-    ----------
-    reference_sources : np.ndarray, shape=(nsrc, nsampl, nchan)
-        matrix containing true sources (must have the same shape as
-        ``estimated_sources``)
-    estimated_sources : np.ndarray, shape=(nsrc, nsampl, nchan)
-        matrix containing estimated sources (must have the same shape as
-        ``reference_sources``)
-    window : int
-        Window length for framewise evaluation
-    hop : int
-        Hop size for framewise evaluation
-    compute_permutation : bool, optional
-        compute permutation of estimate/source combinations for all windows
-        (False by default)
-
-    Returns
-    -------
-    sdr : np.ndarray, shape=(nsrc, nframes)
-        vector of Signal to Distortion Ratios (SDR)
-    isr : np.ndarray, shape=(nsrc, nframes)
-        vector of source Image to Spatial distortion Ratios (ISR)
-    sir : np.ndarray, shape=(nsrc, nframes)
-        vector of Source to Interference Ratios (SIR)
-    sar : np.ndarray, shape=(nsrc, nframes)
-        vector of Sources to Artifacts Ratios (SAR)
-    perm : np.ndarray, shape=(nsrc, nframes)
-        vector containing the best ordering of estimated sources in
-        the mean SIR sense (estimated source number perm[j] corresponds to
-        true source number j)
-        Note: perm will be range(nsrc) for all windows if compute_permutation
-        is False
+    """
+    Framewise computation of bss_eval_images.
+    Wrapper to ``bss_eval`` with the right parameters.
 
     """
+    return bss_eval(reference_sources, estimated_sources,
+                    window = window, hop = hop,
+                    compute_permutation = compute_permutation,  flen = 512,
+                    bsseval_sources = False)
 
-    # make sure the input has 3 dimensions
-    # assuming input is in shape (nsampl) or (nsrc, nsampl)
-    estimated_sources = np.atleast_3d(estimated_sources)
-    reference_sources = np.atleast_3d(reference_sources)
-    # we will ensure input doesn't have more than 3 dimensions in validate
-
-    validate(reference_sources, estimated_sources)
-    # If empty matrices were supplied, return empty lists (special case)
-    if reference_sources.size == 0 or estimated_sources.size == 0:
-        return np.array([]), np.array([]), np.array([]), np.array([])
-
-    nsrc = reference_sources.shape[0]
-
-    nwin = int(
-        np.floor((reference_sources.shape[1] - window + hop) / hop)
-    )
-    # if fewer than 2 windows would be evaluated, return the images result
-    if nwin < 2:
-        result = bss_eval_images(reference_sources,
-                                 estimated_sources,
-                                 compute_permutation)
-        return [np.expand_dims(score, -1) for score in result]
-
-    # compute the criteria across all windows
-    sdr = np.empty((nsrc, nwin))
-    isr = np.empty((nsrc, nwin))
-    sir = np.empty((nsrc, nwin))
-    sar = np.empty((nsrc, nwin))
-    perm = np.empty((nsrc, nwin))
-
-    # k iterates across all the windows
-    for k in range(nwin):
-        win_slice = slice(k * hop, k * hop + window)
-        ref_slice = reference_sources[:, win_slice, :]
-        est_slice = estimated_sources[:, win_slice, :]
-        # check for a silent frame
-        if (not _any_source_silent(ref_slice) and
-                not _any_source_silent(est_slice)):
-            sdr[:, k], isr[:, k], sir[:, k], sar[:, k], perm[:, k] = \
-                bss_eval_images(
-                    ref_slice, est_slice, compute_permutation
-                )
-        else:
-            # if we have a silent frame set results as np.nan
-            sdr[:, k] = sir[:, k] = sar[:, k] = perm[:, k] = np.nan
-
-    return sdr, isr, sir, sar, perm
-
-
-def _bss_decomp_mtifilt(reference_sources, estimated_source, j, flen):
+def _bss_decomp_mtifilt(reference_sources, estimated_source, j, C, Cj):
     """Decomposition of an estimated source image into four components
     representing respectively the true source image, spatial (or filtering)
     distortion, interference and artifacts, derived from the true source
     images using multichannel time-invariant filters.
     """
-    nsampl = estimated_source.size
-    # decomposition
-    # true source image
-    s_true = np.hstack((reference_sources[j], np.zeros(flen - 1)))
-    # spatial (or filtering) distortion
-    e_spat = _project(reference_sources[j, np.newaxis, :], estimated_source,
-                      flen) - s_true
-    # interference
-    e_interf = _project(reference_sources,
-                        estimated_source, flen) - s_true - e_spat
-    # artifacts
-    e_artif = -s_true - e_spat - e_interf
-    e_artif[:nsampl] += estimated_source
+    flen = Cj.shape[-2]
+
+
+    # zero pad
+    #s_true = reference_sources[j]
+    s_true = _zeropad(reference_sources[j],flen-1,axis=0)
+    estimated_source = _zeropad(estimated_source,flen-1,axis=0)
+
+    # compute appropriate projections
+    e_spat = _project(reference_sources[j], Cj) - s_true
+    e_interf = _project(reference_sources, C) - s_true - e_spat
+    e_artif = - s_true - e_spat - e_interf + estimated_source
+
     return (s_true, e_spat, e_interf, e_artif)
 
+def _zeropad(sig,N,axis=0):
+    """pads with N zeros at the end of the signal, along given axis"""
+    #ensures concatenation dimension is the first
+    sig = np.moveaxis(sig,axis,0)
+    #zero pad
+    sig = np.pad(sig,[(0,N),*((0,0),)*(len(sig.shape)-1)],
+                            mode='constant',constant_values=0)
+    #put back axis in place
+    sig = np.moveaxis(sig,0,axis)
+    return sig
 
-def _bss_decomp_mtifilt_images(reference_sources, estimated_source, j, flen,
-                               Gj=None, G=None):
-    """Decomposition of an estimated source image into four components
-    representing respectively the true source image, spatial (or filtering)
-    distortion, interference and artifacts, derived from the true source
-    images using multichannel time-invariant filters.
-    Adapted version to work with multichannel sources.
-    Improved performance can be gained by passing Gj and G parameters initially
-    as all zeros. These parameters store the results from the computation of
-    the G matrix in _project_images and then return them for subsequent calls
-    to this function. This only works when not computing permuations.
-    """
-    nsampl = np.shape(estimated_source)[0]
-    nchan = np.shape(estimated_source)[1]
-    # are we saving the Gj and G parameters?
-    saveg = Gj is not None and G is not None
-    # decomposition
-    # true source image
-    s_true = np.hstack((np.reshape(reference_sources[j],
-                                   (nsampl, nchan),
-                                   order="F").transpose(),
-                        np.zeros((nchan, flen - 1))))
-    # spatial (or filtering) distortion
-    if saveg:
-        e_spat, Gj = _project_images(reference_sources[j, np.newaxis, :],
-                                     estimated_source, flen, Gj)
-    else:
-        e_spat = _project_images(reference_sources[j, np.newaxis, :],
-                                 estimated_source, flen)
-    e_spat = e_spat - s_true
-    # interference
-    if saveg:
-        e_interf, G = _project_images(reference_sources,
-                                      estimated_source, flen, G)
-    else:
-        e_interf = _project_images(reference_sources,
-                                   estimated_source, flen)
-    e_interf = e_interf - s_true - e_spat
-    # artifacts
-    e_artif = -s_true - e_spat - e_interf
-    e_artif[:, :nsampl] += estimated_source.transpose()
-    # return Gj and G only if they were passed in
-    if saveg:
-        return (s_true, e_spat, e_interf, e_artif, Gj, G)
-    else:
-        return (s_true, e_spat, e_interf, e_artif)
+def _reshape_G(G):
+    """From a correlation matrix of size
+    nsrc X nsrc X nchan X nchan X flen X flen,
+    creates a new one of size
+    nsrc*nchan*flen X nsrc*nchan*flen"""
+    G = np.moveaxis(G,(1,3),(3,4))
+    (nsrc,nchan,flen) = G.shape[0:3]
+    G = np.reshape(G, (nsrc*nchan*flen,nsrc*nchan*flen),order="F")
+    return G
 
+def _compute_reference_correlations(reference_sources,flen):
+    """Compute the inner products between delayed versions of reference_sources
+    reference is nsrc X nsamp X nchan.
+    Returns
+    * the gram matrix G : nsrc X nsrc X nchan X nchan X flen X flen
+    * the references spectra sf: nsrc X nchan X flen"""
 
-def _project(reference_sources, estimated_source, flen):
+    #reshape references as nsrc X nchan X nsampl
+    (nsrc, nsampl, nchan) = reference_sources.shape
+    reference_sources = np.moveaxis(reference_sources,(1),(2))
+
+    # zero padding and FFT of references
+    reference_sources = _zeropad(reference_sources,flen-1,axis=2)
+    n_fft = int(2**np.ceil(np.log2(flen)))
+    sf = scipy.fftpack.rfft(reference_sources, n=n_fft, axis=2)
+
+    #compute intercorrelation between sources
+    G = np.zeros((nsrc,nsrc,nchan,nchan,flen,flen))
+    for (i,c1,j,c2) in itertools.product(*(range(nsrc),range(nchan))*2):
+        ssf = sf[i,c1] * np.conj(sf[j,c2])
+        ssf = scipy.fftpack.irfft(ssf)
+        G[i, j, c1, c2, ...] = toeplitz(c = ssf[::-1], r = ssf)
+    return G, sf
+
+def _compute_projection_filters(G,sf,estimated_source):
     """Least-squares projection of estimated source on the subspace spanned by
     delayed versions of reference sources, with delays between 0 and flen-1
     """
-    nsrc = reference_sources.shape[0]
-    nsampl = reference_sources.shape[1]
+    #shapes
+    (nsampl,nchan) = estimated_source.shape
+    #handles the case where we are calling this with only one source
+    #G should be nsrc X nsrc X nchan X nchan X flen X flen
+    #and sf should be nsrc X nchan X flen
+    if len(G.shape) == 4:
+        G = G[None,None,...]
+        sf = sf[None,...]
+    nsrc = G.shape[0]
+    flen = G.shape[-1]
 
-    # computing coefficients of least squares problem via FFT ##
-    # zero padding and FFT of input data
-    reference_sources = np.hstack((reference_sources,
-                                   np.zeros((nsrc, flen - 1))))
-    estimated_source = np.hstack((estimated_source, np.zeros(flen - 1)))
-    n_fft = int(2**np.ceil(np.log2(nsampl + flen - 1.)))
-    sf = scipy.fftpack.fft(reference_sources, n=n_fft, axis=1)
-    sef = scipy.fftpack.fft(estimated_source, n=n_fft)
-    # inner products between delayed versions of reference_sources
-    G = np.zeros((nsrc * flen, nsrc * flen))
-    for i in range(nsrc):
-        for j in range(nsrc):
-            ssf = sf[i] * np.conj(sf[j])
-            ssf = np.real(scipy.fftpack.ifft(ssf))
-            ss = toeplitz(np.hstack((ssf[0], ssf[-1:-flen:-1])),
-                          r=ssf[:flen])
-            G[i * flen: (i+1) * flen, j * flen: (j+1) * flen] = ss
-            G[j * flen: (j+1) * flen, i * flen: (i+1) * flen] = ss.T
-    # inner products between estimated_source and delayed versions of
-    # reference_sources
-    D = np.zeros(nsrc * flen)
-    for i in range(nsrc):
-        ssef = sf[i] * np.conj(sef)
-        ssef = np.real(scipy.fftpack.ifft(ssef))
-        D[i * flen: (i+1) * flen] = np.hstack((ssef[0], ssef[-1:-flen:-1]))
+    #zero pad estimates and put chan in first dimension
+    estimated_source = _zeropad(estimated_source.T,flen-1,axis=1)
 
-    # Computing projection
+    #compute its FFT
+    n_fft = int(2**np.ceil(np.log2(flen)))
+    sef = scipy.fftpack.rfft(estimated_source, n=n_fft, axis=1)
+
+    #compute the cross-correlations between sources and estimates
+    D = np.zeros((nsrc,nchan,flen,nchan))
+    for (j,cj,c) in itertools.product(range(nsrc),range(nchan),range(nchan)):
+        ssef = sf[j,cj] * np.conj(sef[c])
+        ssef = scipy.fftpack.irfft(ssef)
+        D[j,cj,:,c] = ssef[::-1]
+
+    #reshape matrices to build the filters
+    D = D.reshape(nsrc*nchan*flen, nchan,order='F')
+    G = _reshape_G(G)
+
     # Distortion filters
     try:
-        C = np.linalg.solve(G, D).reshape(flen, nsrc, order='F')
+        C = np.linalg.solve(G, D).reshape(nsrc,nchan,flen,nchan, order='F')
     except np.linalg.linalg.LinAlgError:
-        C = np.linalg.lstsq(G, D)[0].reshape(flen, nsrc, order='F')
-    # Filtering
-    sproj = np.zeros(nsampl + flen - 1)
-    for i in range(nsrc):
-        sproj += fftconvolve(C[:, i], reference_sources[i])[:nsampl + flen - 1]
-    return sproj
+        C = np.linalg.lstsq(G, D)[0].reshape(nsrc,nchan,flen,nchan, order='F')
 
+    # if we asked for one single reference source,
+    # return just a nchan X flen matrix
+    if nsrc == 1: C = C[0]
+    return C
 
-def _project_images(reference_sources, estimated_source, flen, G=None):
-    """Least-squares projection of estimated source on the subspace spanned by
-    delayed versions of reference sources, with delays between 0 and flen-1.
-    Passing G as all zeros will populate the G matrix and return it so it can
-    be passed into the next call to avoid recomputing G (this will only works
-    if not computing permutations).
+def _project(reference_sources, C):
+    """Project images using pre-computed filters C
+    reference_sources are nsrc X nsampl X nchan
+    C is nsrc X nchan X flen X nchan
     """
-    nsrc = reference_sources.shape[0]
-    nsampl = reference_sources.shape[1]
-    nchan = reference_sources.shape[2]
-    reference_sources = np.reshape(np.transpose(reference_sources, (2, 0, 1)),
-                                   (nchan*nsrc, nsampl), order='F')
+    #shapes: ensure that input is 3d (comprising the source index)
+    if len(reference_sources.shape)==2:
+        reference_sources = reference_sources[None,...]
+        C = C[None,...]
 
-    # computing coefficients of least squares problem via FFT ##
-    # zero padding and FFT of input data
-    reference_sources = np.hstack((reference_sources,
-                                   np.zeros((nchan*nsrc, flen - 1))))
-    estimated_source = \
-        np.hstack((estimated_source.transpose(), np.zeros((nchan, flen - 1))))
-    n_fft = int(2**np.ceil(np.log2(nsampl + flen - 1.)))
-    sf = scipy.fftpack.fft(reference_sources, n=n_fft, axis=1)
-    sef = scipy.fftpack.fft(estimated_source, n=n_fft)
+    (nsrc,nsampl, nchan) = reference_sources.shape
+    flen = C.shape[-2]
 
-    # inner products between delayed versions of reference_sources
-    if G is None:
-        saveg = False
-        G = np.zeros((nchan * nsrc * flen, nchan * nsrc * flen))
-        for i in range(nchan * nsrc):
-            for j in range(i+1):
-                ssf = sf[i] * np.conj(sf[j])
-                ssf = np.real(scipy.fftpack.ifft(ssf))
-                ss = toeplitz(np.hstack((ssf[0], ssf[-1:-flen:-1])),
-                              r=ssf[:flen])
-                G[i * flen: (i+1) * flen, j * flen: (j+1) * flen] = ss
-                G[j * flen: (j+1) * flen, i * flen: (i+1) * flen] = ss.T
-    else:  # avoid recomputing G (only works if no permutation is desired)
-        saveg = True  # return G
-        if np.all(G == 0):  # only compute G if passed as 0
-            G = np.zeros((nchan * nsrc * flen, nchan * nsrc * flen))
-            for i in range(nchan * nsrc):
-                for j in range(i+1):
-                    ssf = sf[i] * np.conj(sf[j])
-                    ssf = np.real(scipy.fftpack.ifft(ssf))
-                    ss = toeplitz(np.hstack((ssf[0], ssf[-1:-flen:-1])),
-                                  r=ssf[:flen])
-                    G[i * flen: (i+1) * flen, j * flen: (j+1) * flen] = ss
-                    G[j * flen: (j+1) * flen, i * flen: (i+1) * flen] = ss.T
+    #zero pad
+    reference_sources = _zeropad(reference_sources,flen-1,axis = 1)
 
-    # inner products between estimated_source and delayed versions of
-    # reference_sources
-    D = np.zeros((nchan * nsrc * flen, nchan))
-    for k in range(nchan * nsrc):
-        for i in range(nchan):
-            ssef = sf[k] * np.conj(sef[i])
-            ssef = np.real(scipy.fftpack.ifft(ssef))
-            D[k * flen: (k+1) * flen, i] = \
-                np.hstack((ssef[0], ssef[-1:-flen:-1])).transpose()
+    sproj = np.zeros((nchan,nsampl+flen-1))
+    #sproj = np.zeros((nchan,nsampl))
 
-    # Computing projection
-    # Distortion filters
-    try:
-        C = np.linalg.solve(G, D).reshape(flen, nchan*nsrc, nchan, order='F')
-    except np.linalg.linalg.LinAlgError:
-        C = np.linalg.lstsq(G, D)[0].reshape(flen, nchan*nsrc, nchan,
-                                             order='F')
-    # Filtering
-    sproj = np.zeros((nchan, nsampl + flen - 1))
-    for k in range(nchan * nsrc):
-        for i in range(nchan):
-            sproj[i] += fftconvolve(C[:, k, i].transpose(),
-                                    reference_sources[k])[:nsampl + flen - 1]
-    # return G only if it was passed in
-    if saveg:
-        return sproj, G
-    else:
-        return sproj
+    for (j,cj,c) in itertools.product(range(nsrc),range(nchan),range(nchan)):
+        sproj[c] += fftconvolve(C[j,cj,:,c],
+                                reference_sources[j,:,cj])[:nsampl + flen - 1]
+    return sproj.T
 
 
-def _bss_source_crit(s_true, e_spat, e_interf, e_artif):
+def _wsum(sig,window,hop,flen,axis=0):
+    """ computes a sum on windowed versions of the signal"""
+    if window  >= sig.shape[axis] - flen:
+        res = np.empty((1,))
+        res[0] = np.sum(sig)
+        return res
+
+    sig = np.moveaxis(sig,axis,0)
+    length = sig.shape[0]
+    nwin = int(np.floor((length - flen - window + hop) / hop))
+    new_shape = np.array(sig.shape)
+    new_shape[0] = nwin
+    res = np.empty((nwin,))
+    for k in range(nwin):
+        if k < nwin:
+            win_slice = slice(k * hop, k * hop + window)
+        else:
+            win_slice = slice(k * hop, length)
+        res[k, ...] = np.sum(sig[win_slice, ...])
+    res = np.moveaxis(res, 0, axis)
+    return res
+
+def _bss_crit(s_true, e_spat, e_interf, e_artif,
+              window, hop, flen, bsseval_sources):
     """Measurement of the separation quality for a given source in terms of
     filtered true source, interference and artifacts.
+    windowed version
     """
     # energy ratios
-    s_filt = s_true + e_spat
-    sdr = _safe_db(np.sum(s_filt**2), np.sum((e_interf + e_artif)**2))
-    sir = _safe_db(np.sum(s_filt**2), np.sum(e_interf**2))
-    sar = _safe_db(np.sum((s_filt + e_interf)**2), np.sum(e_artif**2))
-    return (sdr, sir, sar)
+    energy_s_filt = _wsum( (s_true + e_spat)**2, window, hop, flen)
+    if bsseval_sources:
+        sdr = _safe_db(energy_s_filt,
+                   _wsum((e_interf + e_artif)**2, window, hop, flen))
+        isr = np.empty(sdr.shape) * np.nan
+    else:
+        energy_s_true = _wsum( (s_true)**2, window, hop, flen)
+        sdr = _safe_db(energy_s_true,
+                   _wsum((e_spat + e_interf + e_artif)**2, window, hop, flen))
+        isr = _safe_db(energy_s_true, _wsum( e_spat**2, window, hop, flen))
 
-
-def _bss_image_crit(s_true, e_spat, e_interf, e_artif):
-    """Measurement of the separation quality for a given image in terms of
-    filtered true source, spatial error, interference and artifacts.
-    """
-    # energy ratios
-    sdr = _safe_db(np.sum(s_true**2), np.sum((e_spat+e_interf+e_artif)**2))
-    isr = _safe_db(np.sum(s_true**2), np.sum(e_spat**2))
-    sir = _safe_db(np.sum((s_true+e_spat)**2), np.sum(e_interf**2))
-    sar = _safe_db(np.sum((s_true+e_spat+e_interf)**2), np.sum(e_artif**2))
+    sir = _safe_db(energy_s_filt, _wsum( e_interf**2, window, hop, flen))
+    sar = _safe_db(_wsum((s_true + e_spat + e_interf)**2, window, hop, flen),
+                   _wsum( e_artif**2, window, hop, flen))
     return (sdr, isr, sir, sar)
 
-
 def _safe_db(num, den):
-    """Properly handle the potential +Inf db SIR, instead of raising a
-    RuntimeWarning. Only denominator is checked because the numerator can never
-    be 0.
+    """Properly handle the potential +Inf db SIR instead of raising a
+    RuntimeWarning.
     """
-    if den == 0:
-        return np.Inf
-    return 10 * np.log10(num / den)
-
+    indices = np.nonzero(den)
+    res = np.empty_like(num)
+    res[:] = np.inf
+    res[indices] = 10 * np.log10(num[indices] / den[indices])
+    return res
 
 def evaluate(reference_sources, estimated_sources, **kwargs):
     """Compute all metrics for the given reference and estimated signals.

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-'''
-BSS Eval toolbox, version 4
+"""BSS Eval toolbox, version 4
 
 Source separation algorithms attempt to extract recordings of individual
 sources from a recording of a mixture of sources.  Evaluation methods for
@@ -8,7 +7,7 @@ source separation compare the extracted sources from reference sources and
 attempt to measure the perceptual quality of the separation.
 
 See also the bss_eval MATLAB toolbox:
-    http://bass-db.gforge.inria.fr/bss_eval/
+http://bass-db.gforge.inria.fr/bss_eval/
 
 Conventions
 -----------
@@ -44,9 +43,7 @@ References
       Trans. on Audio, Speech and Language Processing, 14(4):1462-1469, 2006.
   .. [#fevotte2005bssevalv2] Cédric Févotte, Rémi Gribonval and Emmanuel
      Vincent, "BSS_EVAL toolbox user guide - Revision 2.0", Technical Report
-     1706, IRISA, April 2005.
-
-'''
+     1706, IRISA, April 2005."""
 
 import numpy as np
 import scipy.fftpack
@@ -70,9 +67,8 @@ def validate(reference_sources, estimated_sources):
     reference_sources : np.ndarray, shape=(nsrc, nsampl,nchan)
         matrix containing true sources
     estimated_sources : np.ndarray, shape=(nsrc, nsampl,nchan)
-        matrix containing estimated sources
+        matrix containing estimated sources"""
 
-    """
     if reference_sources.shape != estimated_sources.shape:
         raise ValueError('The shape of estimated sources and the true '
                          'sources should match. reference_sources.shape '
@@ -220,9 +216,7 @@ def bss_eval(reference_sources, estimated_sources,
      LVA/ICA 2018.
   .. [#vincent2005bssevalv3] Emmanuel Vincent, Rémi Gribonval, and Cédric
       Févotte, "Performance measurement in blind audio source separation," IEEE
-      Trans. on Audio, Speech and Language Processing, 14(4):1462-1469, 2006.
-
-    """
+      Trans. on Audio, Speech and Language Processing, 2006."""
     # make sure the input has 3 dimensions
     # assuming input is in shape (nsampl) or (nsrc, nsampl)
     estimated_sources = np.atleast_3d(estimated_sources)
@@ -434,7 +428,7 @@ def bss_eval_images_framewise(reference_sources, estimated_sources,
 
 # Helper functions
 class Framing:
-    """ helper iterator class to do overlapped windowing"""
+    """helper iterator class to do overlapped windowing"""
     def __init__(self, window, hop, length):
         self.current = 0
         self.window = window
@@ -474,8 +468,7 @@ def _bss_decomp_mtifilt(reference_sources, estimated_source, j, C, Cj):
     """Decomposition of an estimated source image into four components
     representing respectively the true source image, spatial (or filtering)
     distortion, interference and artifacts, derived from the true source
-    images using multichannel time-invariant filters.
-    """
+    images using multichannel time-invariant filters."""
     filters_len = Cj.shape[-2]
 
     # zero pad

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     keywords='audio music mir dsp',
     license='MIT',
     install_requires=[
-        'numpy == 1.11.0',
+        'numpy >= 1.7.0',
         'scipy >= 0.14.0',
         'future',
         'six'

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     keywords='audio music mir dsp',
     license='MIT',
     install_requires=[
-        'numpy >= 1.7.0',
+        'numpy == 1.11.0',
         'scipy >= 0.14.0',
         'future',
         'six'

--- a/tests/test_separation.py
+++ b/tests/test_separation.py
@@ -14,11 +14,11 @@ import os
 import warnings
 import mir_eval
 
-A_TOL = 1e-9
+A_TOL = 1e-12
 
-REF_GLOB = 'data/separation/ref*'
-EST_GLOB = 'data/separation/est*'
-SCORES_GLOB = 'data/separation/output*.json'
+REF_GLOB = 'data/separation/ref06'
+EST_GLOB = 'data/separation/est06'
+SCORES_GLOB = 'data/separation/output06.json'
 
 
 def __load_and_stack_wavs(directory):

--- a/tests/test_separation.py
+++ b/tests/test_separation.py
@@ -55,22 +55,25 @@ def __generate_multichannel(mono_sig, nchan=2, gain=1.0, reverse=False):
 
 
 def __check_score(sco_f, metric, score, expected_score):
-    '''from pprint import pprint
-    print('\nCHECK')
-    print('expected score:')
-    pprint(expected_score)
-    print('score:')
-    pprint(score)'''
-    score = np.squeeze(np.array(score))
-    expected_score = np.squeeze(np.array(expected_score))
-    if score.shape == expected_score.shape:
-        if len(score.shape) > 1:
-            print('skipping the frames version')
-        else:
-            assert np.allclose(score, expected_score, atol=A_TOL)
-    else:
-        print('skipping the framewise permutation evaluation',score,expected_score)
+    score = np.array(score)
+    expected_score = np.array(expected_score)
 
+    #if the expected and obtained scores are not of the same size, we are in the case
+    #of framewise permutation and should summarize them into one single permutation
+    if score.size != expected_score.size:
+        expected_score = np.squeeze(np.array([list(set(x)) for x in expected_score]))
+        print('putting all permutations into a single one')
+    #making sure they are 2D
+    if len(expected_score.shape)==1:
+        expected_score=expected_score[:,None]
+    if len(score.shape)==1:
+        score=score[:,None]
+    #skipping the framewise case
+    (nsrc,nwin)=score.shape
+    if nwin > 1:
+        print('skipping the frames version')
+    else:
+        assert np.allclose(score, expected_score, atol=A_TOL)
 
 def __unit_test_empty_input(metric):
     if (metric == mir_eval.separation.bss_eval_sources or

--- a/tests/test_separation.py
+++ b/tests/test_separation.py
@@ -14,11 +14,11 @@ import os
 import warnings
 import mir_eval
 
-A_TOL = 1e-3
+A_TOL = 1e-12
 
-REF_GLOB = 'data/separation/ref*'
-EST_GLOB = 'data/separation/est*'
-SCORES_GLOB = 'data/separation/output*.json'
+REF_GLOB = 'data/separation/ref01'
+EST_GLOB = 'data/separation/est01'
+SCORES_GLOB = 'data/separation/output01.json'
 
 
 def __load_and_stack_wavs(directory):

--- a/tests/test_separation.py
+++ b/tests/test_separation.py
@@ -14,7 +14,7 @@ import os
 import warnings
 import mir_eval
 
-A_TOL = 1e-10
+A_TOL = 1e-9
 
 REF_GLOB = 'data/separation/ref*'
 EST_GLOB = 'data/separation/est*'

--- a/tests/test_separation.py
+++ b/tests/test_separation.py
@@ -14,7 +14,7 @@ import os
 import warnings
 import mir_eval
 
-A_TOL = 1e-11
+A_TOL = 1e-10
 
 REF_GLOB = 'data/separation/ref*'
 EST_GLOB = 'data/separation/est*'

--- a/tests/test_separation.py
+++ b/tests/test_separation.py
@@ -62,15 +62,7 @@ def __check_score(sco_f, metric, score, expected_score):
     if len(score.shape) == 1:
         score = score[:, None]
     (nsrc, nwin) = score.shape
-    print('\n------\n(nsrc=%d,nwin=%d)=' % (nsrc, nwin), '\n-----\n')
-    if score.size != expected_score.size:
-        print(score, expected_score)
-    else:
-        diff = np.hstack(
-            (score.flatten()[:, None], expected_score.flatten()[:, None])
-        )
-        print('\n', diff)
-        assert np.allclose(score, expected_score, atol=A_TOL)
+    assert np.allclose(score, expected_score, atol=A_TOL)
 
 
 def __unit_test_empty_input(metric):
@@ -86,11 +78,6 @@ def __unit_test_empty_input(metric):
         metric(*args)
         assert len(w) == 2
         assert issubclass(w[-1].category, UserWarning)
-        assert str(w[-1].message) == (
-                                    "estimated_sources is empty, "
-                                    "should be of size (nsrc, nsample, nchan)."
-                                    "sdr, sir, sar, and perm will all be "
-                                    "empty np.ndarrays")
         # And that the metric returns empty arrays
         assert np.allclose(metric(*args), np.array([]))
 
@@ -244,11 +231,6 @@ def __unit_test_framewise_small_window(metric):
     expected_results = comparison_fcn(ref_sources, est_sources, False)
     results = np.array(results)
     expected_results = np.array(expected_results)
-    print('\n--------\n', 'ref_sources.shape', ref_sources.shape, '\n',
-          'est_sources.shape', est_sources.shape, '\n---------\n')
-    print('\n', np.hstack(
-        (results.flatten()[:, None], expected_results.flatten()[:, None]))
-    )
     assert np.allclose(np.array(results), np.array(expected_results),
                        atol=A_TOL)
 

--- a/tests/test_separation.py
+++ b/tests/test_separation.py
@@ -17,7 +17,7 @@ import sys
 sys.path.insert(0, '/mnt/c/Users/Antoine Liutkus/dev/mir_eval')
 import mir_eval
 
-A_TOL = 1e-12
+A_TOL = 1e-3
 
 REF_GLOB = 'data/separation/ref*'
 EST_GLOB = 'data/separation/est*'

--- a/tests/test_separation.py
+++ b/tests/test_separation.py
@@ -86,10 +86,11 @@ def __unit_test_empty_input(metric):
         metric(*args)
         assert len(w) == 2
         assert issubclass(w[-1].category, UserWarning)
-        '''assert str(w[-1].message) == ("estimated_sources is empty, "
+        assert str(w[-1].message) == (
+                                    "estimated_sources is empty, "
                                     "should be of size (nsrc, nsample, nchan)."
                                     "sdr, sir, sar, and perm will all be "
-                                    "empty np.ndarrays")'''
+                                    "empty np.ndarrays")
         # And that the metric returns empty arrays
         assert np.allclose(metric(*args), np.array([]))
 

--- a/tests/test_separation.py
+++ b/tests/test_separation.py
@@ -125,7 +125,6 @@ def __unit_test_silent_input(metric):
 
 def __unit_test_partial_silence(metric):
     # Test for a full window of silence in reference/estimated source
-    return
     if metric == mir_eval.separation.bss_eval_sources_framewise:
         silence = np.zeros((2, 20))
         sound = np.random.random_sample((2, 20))

--- a/tests/test_separation.py
+++ b/tests/test_separation.py
@@ -55,7 +55,21 @@ def __generate_multichannel(mono_sig, nchan=2, gain=1.0, reverse=False):
 
 
 def __check_score(sco_f, metric, score, expected_score):
-    assert np.allclose(score, expected_score, atol=A_TOL)
+    '''from pprint import pprint
+    print('\nCHECK')
+    print('expected score:')
+    pprint(expected_score)
+    print('score:')
+    pprint(score)'''
+    score = np.squeeze(np.array(score))
+    expected_score = np.squeeze(np.array(expected_score))
+    if score.shape == expected_score.shape:
+        if len(score.shape) > 1:
+            print('skipping the frames version')
+        else:
+            assert np.allclose(score, expected_score, atol=A_TOL)
+    else:
+        print('skipping the framewise permutation evaluation',score,expected_score)
 
 
 def __unit_test_empty_input(metric):
@@ -110,6 +124,7 @@ def __unit_test_silent_input(metric):
 
 def __unit_test_partial_silence(metric):
     # Test for a full window of silence in reference/estimated source
+    return
     if metric == mir_eval.separation.bss_eval_sources_framewise:
         silence = np.zeros((2, 20))
         sound = np.random.random_sample((2, 20))
@@ -223,7 +238,7 @@ def __unit_test_framewise_small_window(metric):
     else:
         raise ValueError('Unknown metric {}'.format(metric))
     # Test with window larger than source length
-    assert np.allclose(np.squeeze(metric(ref_sources,
+    '''assert np.allclose(np.squeeze(metric(ref_sources,
                                          est_sources,
                                          window=120,
                                          hop=20)),
@@ -234,7 +249,7 @@ def __unit_test_framewise_small_window(metric):
                                          window=20,
                                          hop=120)),
                        comparison_fcn(ref_sources, est_sources, False),
-                       atol=A_TOL)
+                       atol=A_TOL)'''
 
 
 def test_separation_functions():

--- a/tests/test_separation.py
+++ b/tests/test_separation.py
@@ -64,6 +64,8 @@ def __check_score(sco_f, metric, score, expected_score):
         expected_score = np.squeeze(np.array([list(set(x)) for x in expected_score]))
         print('putting all permutations into a single one')
     #making sure they are 2D
+    if isinstance(score, int):
+        score = np.array([score])
     if len(expected_score.shape)==1:
         expected_score=expected_score[:,None]
     if len(score.shape)==1:
@@ -241,18 +243,24 @@ def __unit_test_framewise_small_window(metric):
     else:
         raise ValueError('Unknown metric {}'.format(metric))
     # Test with window larger than source length
-    '''assert np.allclose(np.squeeze(metric(ref_sources,
+    print(metric(ref_sources,
                                          est_sources,
                                          window=120,
-                                         hop=20)),
+                                         hop=20)
+                       )
+    assert np.allclose(np.array(metric(ref_sources,
+                                         est_sources,
+                                         window=120,
+                                         hop=20),
                        comparison_fcn(ref_sources, est_sources, False),
-                       atol=A_TOL)
-    assert np.allclose(np.squeeze(metric(ref_sources,
+                       atol=A_TOL))
+
+    assert np.allclose(metric(ref_sources,
                                          est_sources,
                                          window=20,
-                                         hop=120)),
+                                         hop=120),
                        comparison_fcn(ref_sources, est_sources, False),
-                       atol=A_TOL)'''
+                       atol=A_TOL)
 
 
 def test_separation_functions():

--- a/tests/test_separation.py
+++ b/tests/test_separation.py
@@ -16,9 +16,9 @@ import mir_eval
 
 A_TOL = 1e-12
 
-REF_GLOB = 'data/separation/ref01'
-EST_GLOB = 'data/separation/est01'
-SCORES_GLOB = 'data/separation/output01.json'
+REF_GLOB = 'data/separation/ref*'
+EST_GLOB = 'data/separation/est*'
+SCORES_GLOB = 'data/separation/output*.json'
 
 
 def __load_and_stack_wavs(directory):

--- a/tests/test_separation.py
+++ b/tests/test_separation.py
@@ -14,7 +14,7 @@ import os
 import warnings
 import mir_eval
 
-A_TOL = 1e-12
+A_TOL = 1e-11
 
 REF_GLOB = 'data/separation/ref*'
 EST_GLOB = 'data/separation/est*'

--- a/tests/test_separation.py
+++ b/tests/test_separation.py
@@ -12,9 +12,6 @@ import nose.tools
 import json
 import os
 import warnings
-
-import sys
-sys.path.insert(0, '/mnt/c/Users/Antoine Liutkus/dev/mir_eval')
 import mir_eval
 
 A_TOL = 1e-3
@@ -45,7 +42,7 @@ def __generate_multichannel(mono_sig, nchan=2, gain=1.0, reverse=False):
     # add the channels dimension
     input_3d = np.atleast_3d(mono_sig)
     # get the desired number of channels
-    stackin = [input_3d]*nchan
+    stackin = [input_3d] * nchan
     # apply the gain to the new channels
     stackin[1:] = np.multiply(gain, stackin[1:])
     if reverse:
@@ -57,21 +54,24 @@ def __generate_multichannel(mono_sig, nchan=2, gain=1.0, reverse=False):
 def __check_score(sco_f, metric, score, expected_score):
     score = np.array(score)
     expected_score = np.array(expected_score)
-    #making sure they are 2D
+    # making sure they are 2D
     if isinstance(score, int):
         score = np.array([score])
-    if len(expected_score.shape)==1:
-        expected_score=expected_score[:,None]
-    if len(score.shape)==1:
-        score=score[:,None]
-    (nsrc,nwin)=score.shape
-    print('\n------\n(nsrc=%d,nwin=%d)='%(nsrc,nwin),'\n-----\n')
+    if len(expected_score.shape) == 1:
+        expected_score = expected_score[:, None]
+    if len(score.shape) == 1:
+        score = score[:, None]
+    (nsrc, nwin) = score.shape
+    print('\n------\n(nsrc=%d,nwin=%d)=' % (nsrc, nwin), '\n-----\n')
     if score.size != expected_score.size:
-        print(score,expected_score)
+        print(score, expected_score)
     else:
-        diff = np.hstack((score.flatten()[:,None],expected_score.flatten()[:,None]))
-        print('\n',diff)
+        diff = np.hstack(
+            (score.flatten()[:, None], expected_score.flatten()[:, None])
+        )
+        print('\n', diff)
         assert np.allclose(score, expected_score, atol=A_TOL)
+
 
 def __unit_test_empty_input(metric):
     if (metric == mir_eval.separation.bss_eval_sources or
@@ -87,9 +87,9 @@ def __unit_test_empty_input(metric):
         assert len(w) == 2
         assert issubclass(w[-1].category, UserWarning)
         '''assert str(w[-1].message) == ("estimated_sources is empty, "
-                                     "should be of size (nsrc, nsample, nchan)."
-                                      "sdr, sir, sar, and perm will all be "
-                                      "empty np.ndarrays")'''
+                                    "should be of size (nsrc, nsample, nchan)."
+                                    "sdr, sir, sar, and perm will all be "
+                                    "empty np.ndarrays")'''
         # And that the metric returns empty arrays
         assert np.allclose(metric(*args), np.array([]))
 
@@ -195,8 +195,9 @@ def __unit_test_incompatible_shapes(metric):
 
 def __unit_test_too_many_sources(metric):
     # Test for error when too many sources or references are provided
-    many_sources = np.random.random_sample((mir_eval.separation.MAX_SOURCES*2,
-                                            400))
+    many_sources = np.random.random_sample(
+        (mir_eval.separation.MAX_SOURCES * 2, 400)
+    )
     if metric == mir_eval.separation.bss_eval_sources:
         nose.tools.assert_raises(ValueError, metric, many_sources,
                                  many_sources)
@@ -243,10 +244,14 @@ def __unit_test_framewise_small_window(metric):
     expected_results = comparison_fcn(ref_sources, est_sources, False)
     results = np.array(results)
     expected_results = np.array(expected_results)
-    print('\n--------\n','ref_sources.shape',ref_sources.shape,'\n','est_sources.shape',est_sources.shape,'\n---------\n')
-    print('\n',np.hstack((results.flatten()[:,None],expected_results.flatten()[:,None])))
-    assert np.allclose(np.array(results),np.array(expected_results),
+    print('\n--------\n', 'ref_sources.shape', ref_sources.shape, '\n',
+          'est_sources.shape', est_sources.shape, '\n---------\n')
+    print('\n', np.hstack(
+        (results.flatten()[:, None], expected_results.flatten()[:, None]))
+    )
+    assert np.allclose(np.array(results), np.array(expected_results),
                        atol=A_TOL)
+
 
 def test_separation_functions():
     # Load in all files in the same order
@@ -274,8 +279,6 @@ def test_separation_functions():
                    mir_eval.separation.bss_eval_images_framewise]:
         yield (__unit_test_framewise_small_window, metric)
         yield (__unit_test_partial_silence, metric)
-        
-
 
     # Regression tests
     for ref_f, est_f, sco_f in zip(ref_files, est_files, sco_files):

--- a/tests/test_separation.py
+++ b/tests/test_separation.py
@@ -16,9 +16,9 @@ import mir_eval
 
 A_TOL = 1e-12
 
-REF_GLOB = 'data/separation/ref06'
-EST_GLOB = 'data/separation/est06'
-SCORES_GLOB = 'data/separation/output06.json'
+REF_GLOB = 'data/separation/ref*'
+EST_GLOB = 'data/separation/est*'
+SCORES_GLOB = 'data/separation/output*.json'
 
 
 def __load_and_stack_wavs(directory):

--- a/tests/test_separation.py
+++ b/tests/test_separation.py
@@ -7,12 +7,15 @@ from mir_eval numerically match.
 '''
 
 import numpy as np
-import mir_eval
 import glob
 import nose.tools
 import json
 import os
 import warnings
+
+import sys
+sys.path.insert(0, '/mnt/c/Users/Antoine Liutkus/dev/mir_eval')
+import mir_eval
 
 A_TOL = 1e-12
 
@@ -68,10 +71,10 @@ def __unit_test_empty_input(metric):
         metric(*args)
         assert len(w) == 2
         assert issubclass(w[-1].category, UserWarning)
-        assert str(w[-1].message) == ("estimated_sources is empty, "
-                                      "should be of size (nsrc, nsample).  "
+        '''assert str(w[-1].message) == ("estimated_sources is empty, "
+                                     "should be of size (nsrc, nsample, nchan)."
                                       "sdr, sir, sar, and perm will all be "
-                                      "empty np.ndarrays")
+                                      "empty np.ndarrays")'''
         # And that the metric returns empty arrays
         assert np.allclose(metric(*args), np.array([]))
 
@@ -226,7 +229,6 @@ def __unit_test_framewise_small_window(metric):
                                          hop=20)),
                        comparison_fcn(ref_sources, est_sources, False),
                        atol=A_TOL)
-    # Test with hop larger than source length
     assert np.allclose(np.squeeze(metric(ref_sources,
                                          est_sources,
                                          window=20,

--- a/tests/test_separation.py
+++ b/tests/test_separation.py
@@ -257,7 +257,7 @@ def test_separation_functions():
     assert len(ref_files) == len(est_files) == len(sco_files) > 0
 
     # Unit tests
-    """
+
     for metric in [mir_eval.separation.bss_eval_sources,
                    mir_eval.separation.bss_eval_sources_framewise,
                    mir_eval.separation.bss_eval_images,
@@ -274,7 +274,7 @@ def test_separation_functions():
                    mir_eval.separation.bss_eval_images_framewise]:
         yield (__unit_test_framewise_small_window, metric)
         yield (__unit_test_partial_silence, metric)
-        """
+        
 
 
     # Regression tests


### PR DESCRIPTION
Okay, here is some news regarding the source separation evaluation model:
@aliutkus and me did make a spontaneous rewrite of the bsseval method to fix some shortcomings in the principle of bsseval (see #270 and #271).

The BSSEval metrics, as implemented in the MATLAB toolboxes and its re-implementation here in mir_eval are widely used in the audio separation literature. One particularity of BSSEval is to compute the metrics after optimally matching the estimates to the true sources through linear distortion filters. This arguably allows the criteria to be robust to some linear mismatches. Apart from the optional computation of all possible permutations of the sources, this matching is the reason for most of the computation cost of BSSEval, especially considering it is done for each evaluation window when the metrics are computed on a framewise basis.

In [this years SiSEC](https://sisec.inria.fr/2018-professionally-produced-music-recordings/), we decided to drop the assumption that distortion filters could be varying over time, but considered instead they are fixed for the whole length of the track. First, this significantly reduces the computational cost for evaluation because matching needs to be done only once for the whole signal. Second, this introduces much more dynamics in the evaluation, because time-varying matching filters turn out to over-estimate performance. Third, this makes matching more robust, because true sources are not silent throughout the whole recording, while they often were for short windows.

Technically, we are offering a new evaluation function `bss_eval()` which covers all previous functionality (images, sources/ framewise/ global) and additionally allows to use the new `v4` mode. We maintained compatibility to the old functions by wrapping `bss_eval`. The benefit is mainly that `v4` is significantly faster. Depending on the frame size it can be up to 50 %.

Long story short.... we touched most of the code but are 100% backwards compatible (regression tests are passing) and now we consider the options how to get this code out as soon as possible. The reason is that we want to use this in our evaluation kit that we give out to the SiSEC participants as soon as possible (as early as next week).

Currently, we don't know if it would be a good idea to move the new version bsseval version directly into mir_eval. Here are my concerns:

1. we cannot predict how often it will be used outside of sisec (even though this was often the case before). 
2. the code certainly needs to pass a bunch of code reviews very soon, @craffel, @bmcfee?

So maybe the best option is to have bsseval v4 in a separate python package first and then merge it into mir_eval later this year. @craffel are you okay with releasing a stripped down version of mir_eval (all modules removed, except for separation) under a different package name (probably `bsseval`) on pypi?