### PR TITLE
Allow one reference tempo and both estimate tempi to be zero. The ide…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ notifications:
 
 python:
     - "2.7"
-    - "3.4"
     - "3.5"
 
 before_install:
@@ -20,7 +19,7 @@ before_install:
     - conda config --set always_yes yes --set changeps1 no
     - conda update -q conda
     - conda info -a
-    - deps='pip atlas numpy scipy sphinx nose six future pep8 matplotlib decorator'
+    - deps='pip atlas numpy scipy sphinx nose six future pep8 matplotlib>=2.1.0,<3 decorator'
     - conda create -q -n test-environment "python=$TRAVIS_PYTHON_VERSION" $deps 
     - source activate test-environment
     - pip install python-coveralls

--- a/mir_eval/chord.py
+++ b/mir_eval/chord.py
@@ -587,7 +587,7 @@ def rotate_bitmap_to_root(bitmap, chord_root):
     idxs = list(np.nonzero(bitmap))
     idxs[-1] = (idxs[-1] + chord_root) % 12
     abs_bitmap = np.zeros_like(bitmap)
-    abs_bitmap[idxs] = 1
+    abs_bitmap[tuple(idxs)] = 1
     return abs_bitmap
 
 

--- a/mir_eval/hierarchy.py
+++ b/mir_eval/hierarchy.py
@@ -302,8 +302,8 @@ def _gauc(ref_lca, est_lca, transitive, window):
         est_score = est_lca[query, results]
 
         # Densify the results
-        ref_score = np.asarray(ref_score.todense()).squeeze()
-        est_score = np.asarray(est_score.todense()).squeeze()
+        ref_score = ref_score.toarray().squeeze()
+        est_score = est_score.toarray().squeeze()
 
         # Don't count the query as a result
         # when query < window, query itself is the index within the slice

--- a/mir_eval/tempo.py
+++ b/mir_eval/tempo.py
@@ -46,8 +46,9 @@ def validate_tempi(tempi, reference=True):
     if not np.all(np.isfinite(tempi)) or np.any(tempi < 0):
         raise ValueError('tempi={} must be non-negative numbers'.format(tempi))
 
-    if reference and np.all(tempi == 0) :
-        raise ValueError('reference tempi={} must have one value greater than zero'.format(tempi))
+    if reference and np.all(tempi == 0):
+        raise ValueError('reference tempi={} must have one'
+                         ' value greater than zero'.format(tempi))
 
 
 def validate(reference_tempi, reference_weight, estimated_tempi):
@@ -130,7 +131,8 @@ def detection(reference_tempi, reference_weight, estimated_tempi, tol=0.08):
     for i, ref_t in enumerate(reference_tempi):
         if ref_t > 0:
             # Compute the relative error for this reference tempo
-            relative_error = np.min(np.abs(ref_t - estimated_tempi) / float(ref_t))
+            f_ref_t = float(ref_t)
+            relative_error = np.min(np.abs(ref_t - estimated_tempi) / f_ref_t)
 
             # Count the hits
             hits[i] = relative_error <= tol

--- a/mir_eval/tempo.py
+++ b/mir_eval/tempo.py
@@ -8,8 +8,8 @@ description of the task and evaluation criteria.
 Conventions
 -----------
 
-Reference and estimated tempi should be positive, and provided in ascending order
-as a numpy array of length 2.
+Reference and estimated tempi should be positive, and provided in ascending
+order as a numpy array of length 2.
 
 The weighting value from the reference must be a float in the range [0, 1].
 

--- a/mir_eval/tempo.py
+++ b/mir_eval/tempo.py
@@ -21,6 +21,7 @@ Metrics
 
 '''
 
+import warnings
 import numpy as np
 import collections
 from . import util
@@ -105,14 +106,17 @@ def detection(reference_tempi, reference_weight, estimated_tempi, tol=0.08):
 
         If the reference weight is not in the range [0, 1]
 
-        If ``tol <= 0`` or ``tol > 1``.
+        If ``tol < 0`` or ``tol > 1``.
     """
 
     validate(reference_tempi, reference_weight, estimated_tempi)
 
-    if tol <= 0 or tol > 1:
+    if tol < 0 or tol > 1:
         raise ValueError('invalid tolerance {}: must lie in the range '
-                         '(0, 1]'.format(tol))
+                         '[0, 1]'.format(tol))
+    if tol == 0.:
+        warnings.warn('A tolerance of 0.0 may not '
+                      'lead to the results you expect.')
 
     relative_errors = []
     hits = []

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,6 @@ setup(
     extras_require={
         'display': ['matplotlib>=1.5.0',
                     'scipy>=1.0.0'],
-        'testing': ['matplotlib>=2.1.0']
+        'testing': ['matplotlib>=2.1.0,<3']
     }
 )

--- a/tests/test_hierarchy.py
+++ b/tests/test_hierarchy.py
@@ -323,7 +323,7 @@ def test_meet():
 
     # Is it the right type?
     assert isinstance(meet, scipy.sparse.csr_matrix)
-    meet = meet.todense()
+    meet = meet.toarray()
 
     # Does it have the right shape?
     assert meet.shape == (10, 10)

--- a/tests/test_separation.py
+++ b/tests/test_separation.py
@@ -14,7 +14,7 @@ import json
 import os
 import warnings
 
-A_TOL = 1e-12
+A_TOL = 1e-2
 
 REF_GLOB = 'data/separation/ref*'
 EST_GLOB = 'data/separation/est*'

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -51,13 +51,13 @@ def test_tempo_pass():
     for good_tempo in [np.array([50, 50]), np.array([0, 50]),
                        np.array([50, 0])]:
         yield mir_eval.tempo.detection, good_tempo,\
-              good_weight, good_est, good_tol
+            good_weight, good_est, good_tol
         yield mir_eval.tempo.detection, good_ref,\
-              good_weight, good_tempo, good_tol
+            good_weight, good_tempo, good_tol
 
     # allow both estimates to be zero
     yield mir_eval.tempo.detection, good_ref,\
-          good_weight, np.array([0, 0]), good_tol
+        good_weight, np.array([0, 0]), good_tol
 
 
 def test_tempo_fail():

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -2,6 +2,7 @@
 '''
 Unit tests for mir_eval.tempo
 '''
+import warnings
 
 import numpy as np
 import mir_eval
@@ -24,6 +25,23 @@ def __check_score(sco_f, metric, score, expected_score):
     assert np.allclose(score, expected_score, atol=A_TOL)
 
 
+def test_zero_tolerance_pass():
+    good_ref = np.array([60, 120])
+    good_weight = 0.5
+    good_est = np.array([120, 180])
+    zero_tol = 0.0
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        # Try to produce the warning
+        mir_eval.tempo.detection(good_ref, good_weight, good_est, tol=zero_tol)
+
+        assert len(w) == 1
+        assert issubclass(w[-1].category, UserWarning)
+        assert str(w[-1].message) == 'A tolerance of 0.0 may ' \
+                                     'not lead to the results you expect.'
+
+
 def test_tempo_fail():
 
     @raises(ValueError)
@@ -42,7 +60,7 @@ def test_tempo_fail():
     for bad_weight in [-1, 1.5]:
         yield __test, good_ref, bad_weight, good_est, good_tol
 
-    for bad_tol in [-1, 0, 1.5]:
+    for bad_tol in [-1, 1.5]:
         yield __test, good_ref, good_weight, good_est, bad_tol
 
 

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -42,6 +42,20 @@ def test_zero_tolerance_pass():
                                      'not lead to the results you expect.'
 
 
+def test_tempo_pass():
+    good_ref = np.array([60, 120])
+    good_weight = 0.5
+    good_est = np.array([120, 180])
+    good_tol = 0.08
+
+    for good_tempo in [np.array([50, 50]), np.array([0, 50]), np.array([50, 0])]:
+        yield mir_eval.tempo.detection, good_tempo, good_weight, good_est, good_tol
+        yield mir_eval.tempo.detection, good_ref, good_weight, good_tempo, good_tol
+
+    # allow both estimates to be zero
+    yield mir_eval.tempo.detection, good_ref, good_weight, np.array([0, 0]), good_tol
+
+
 def test_tempo_fail():
 
     @raises(ValueError)
@@ -53,7 +67,8 @@ def test_tempo_fail():
     good_est = np.array([120, 180])
     good_tol = 0.08
 
-    for bad_tempo in [np.array([-1, 50]), np.array([0, 1, 2]), np.array([0])]:
+    for bad_tempo in [np.array([-1, -1]), np.array([-1, 0]),
+                      np.array([-1, 50]), np.array([0, 1, 2]), np.array([0])]:
         yield __test, bad_tempo, good_weight, good_est, good_tol
         yield __test, good_ref, good_weight, bad_tempo, good_tol
 
@@ -62,6 +77,9 @@ def test_tempo_fail():
 
     for bad_tol in [-1, 1.5]:
         yield __test, good_ref, good_weight, good_est, bad_tol
+
+    # don't allow both references to be zero
+    yield __test, np.array([0, 0]), good_weight, good_ref, good_tol
 
 
 def test_tempo_regression():

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -48,12 +48,16 @@ def test_tempo_pass():
     good_est = np.array([120, 180])
     good_tol = 0.08
 
-    for good_tempo in [np.array([50, 50]), np.array([0, 50]), np.array([50, 0])]:
-        yield mir_eval.tempo.detection, good_tempo, good_weight, good_est, good_tol
-        yield mir_eval.tempo.detection, good_ref, good_weight, good_tempo, good_tol
+    for good_tempo in [np.array([50, 50]), np.array([0, 50]),
+                       np.array([50, 0])]:
+        yield mir_eval.tempo.detection, good_tempo,\
+              good_weight, good_est, good_tol
+        yield mir_eval.tempo.detection, good_ref,\
+              good_weight, good_tempo, good_tol
 
     # allow both estimates to be zero
-    yield mir_eval.tempo.detection, good_ref, good_weight, np.array([0, 0]), good_tol
+    yield mir_eval.tempo.detection, good_ref,\
+          good_weight, np.array([0, 0]), good_tol
 
 
 def test_tempo_fail():


### PR DESCRIPTION
…a here is that some tracks in the ground truth may not be ambiguous and some estimators might be unable to produce any reasonable value and therefore choose zero for both estimate tempi.

This is a little more than what we had talked about in #298, but I believe it to be reasonable.