### PR TITLE
Loosen separation test tolerance

### DIFF
--- a/tests/test_separation.py
+++ b/tests/test_separation.py
@@ -14,7 +14,7 @@ import json
 import os
 import warnings
 
-A_TOL = 1e-3
+A_TOL = 1e-2
 
 REF_GLOB = 'data/separation/ref*'
 EST_GLOB = 'data/separation/est*'

--- a/tests/test_separation.py
+++ b/tests/test_separation.py
@@ -14,7 +14,7 @@ import json
 import os
 import warnings
 
-A_TOL = 1e-12
+A_TOL = 1e-3
 
 REF_GLOB = 'data/separation/ref*'
 EST_GLOB = 'data/separation/est*'


### PR DESCRIPTION
For some tests, the difference between the scores produced by Travis' build and my own build is as large as 3.89588121e-04. This was causing Travis to fail. In practice, we shouldn't care much about differences larger than 10e-3 for separation tasks since it would be very unusual for anyone to pay attention to differences this small when comparing source separation algorithms.