### PR TITLE
Use toarray instead of todense for sparse matrices

### DIFF
--- a/mir_eval/hierarchy.py
+++ b/mir_eval/hierarchy.py
@@ -302,8 +302,8 @@ def _gauc(ref_lca, est_lca, transitive, window):
         est_score = est_lca[query, results]
 
         # Densify the results
-        ref_score = np.asarray(ref_score.todense()).squeeze()
-        est_score = np.asarray(est_score.todense()).squeeze()
+        ref_score = ref_score.toarray().squeeze()
+        est_score = est_score.toarray().squeeze()
 
         # Don't count the query as a result
         # when query < window, query itself is the index within the slice

--- a/tests/test_hierarchy.py
+++ b/tests/test_hierarchy.py
@@ -323,7 +323,7 @@ def test_meet():
 
     # Is it the right type?
     assert isinstance(meet, scipy.sparse.csr_matrix)
-    meet = meet.todense()
+    meet = meet.toarray()
 
     # Does it have the right shape?
     assert meet.shape == (10, 10)


### PR DESCRIPTION
todense returns a numpy matrix object, whereas toarray returns a numpy ndarray. The former causes a DeprecationWarning. The flood of DeprecationWarnings in our tests eventually causes Travis to fail.