### PR TITLE
Use tuple index in chord.rotate_bitmap_to_root

### DIFF
--- a/mir_eval/chord.py
+++ b/mir_eval/chord.py
@@ -587,7 +587,7 @@ def rotate_bitmap_to_root(bitmap, chord_root):
     idxs = list(np.nonzero(bitmap))
     idxs[-1] = (idxs[-1] + chord_root) % 12
     abs_bitmap = np.zeros_like(bitmap)
-    abs_bitmap[idxs] = 1
+    abs_bitmap[tuple(idxs)] = 1
     return abs_bitmap
 
 


### PR DESCRIPTION
Using a list causes a warning with the latest numpy. Fixes #306.