### PR TITLE
Require matplotlib <3 for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
     - conda config --set always_yes yes --set changeps1 no
     - conda update -q conda
     - conda info -a
-    - deps='pip atlas numpy scipy sphinx nose six future pep8 matplotlib decorator'
+    - deps='pip atlas numpy scipy sphinx nose six future pep8 matplotlib>=2.1.0,<3 decorator'
     - conda create -q -n test-environment "python=$TRAVIS_PYTHON_VERSION" $deps 
     - source activate test-environment
     - pip install python-coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ notifications:
 
 python:
     - "2.7"
-    - "3.4"
     - "3.5"
 
 before_install:

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,6 @@ setup(
     extras_require={
         'display': ['matplotlib>=1.5.0',
                     'scipy>=1.0.0'],
-        'testing': ['matplotlib>=2.1.0']
+        'testing': ['matplotlib>=2.1.0,<3']
     }
 )


### PR DESCRIPTION
matplotlib v3+ omits the matplotlib.testing.noseclasses module which our tests use. This change forces using an old version of matplotlib as a temporary fix. Fixes #308