### PR TITLE
Fix interpolation in sonify.time_frequency

### DIFF
--- a/mir_eval/sonify.py
+++ b/mir_eval/sonify.py
@@ -163,7 +163,7 @@ def time_frequency(gram, frequencies, times, fs, function=np.sin, length=None,
             gram_interpolator = interp1d(
                 time_centers, gram[n, :],
                 kind='linear', bounds_error=False,
-                fill_value=(gram[n,0],gram[n,-1]))
+                fill_value=(gram[n, 0], gram[n, -1]))
         # If only one time point, create constant interpolator
         else:
             gram_interpolator = _const_interpolator(gram[n, 0])

--- a/mir_eval/sonify.py
+++ b/mir_eval/sonify.py
@@ -163,7 +163,7 @@ def time_frequency(gram, frequencies, times, fs, function=np.sin, length=None,
             gram_interpolator = interp1d(
                 time_centers, gram[n, :],
                 kind='linear', bounds_error=False,
-                fill_value=0.0)
+                fill_value=(gram[n,0],gram[n,-1]))
         # If only one time point, create constant interpolator
         else:
             gram_interpolator = _const_interpolator(gram[n, 0])


### PR DESCRIPTION
This fixes #322. The change is (over)-detailed in [this comment](https://github.com/craffel/mir_eval/issues/322#issuecomment-546654110) but the gist is: because the interpolator used in `time_frequency` uses the midpoints of chord intervals as boundaries for linear interpolation, it misses the period before the midpoint of the first chord interval and the period after the midpoint of the last chord interval. 

Using a tuple in `fill_value` allows us to tell the interpolator to handle the case where we're before the first midpoint or after the last.