### PR TITLE
Stop testing 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ notifications:
     email: false
 
 python:
-    - "2.7"
     - "3.5"
 
 before_install:


### PR DESCRIPTION
Python 2 had its end-of-life on January 1st, and the test is now broken by a downstream library that no longer supports Python 2, so we should go ahead and stop testing it.