### PR TITLE
Cast n_voiced to int in display.multipitch

### DIFF
--- a/mir_eval/display.py
+++ b/mir_eval/display.py
@@ -648,7 +648,7 @@ def multipitch(times, frequencies, midi=False, unvoiced=False, ax=None,
             freqs = hz_to_midi(freqs)
 
         n_voiced = sum(voicings)
-        voiced_times.extend([t] * n_voiced)
+        voiced_times.extend([t] * int(n_voiced))
         voiced_freqs.extend(freqs[voicings])
         unvoiced_times.extend([t] * (len(freqs) - n_voiced))
         unvoiced_freqs.extend(freqs[~voicings])


### PR DESCRIPTION
This avoids an error where we are multiplying a list (`[t]`) by a `np.float64` instead of an integer dtype.