### PR TITLE
resample_multipitch improvement

### DIFF
--- a/tests/test_multipitch.py
+++ b/tests/test_multipitch.py
@@ -77,10 +77,50 @@ def test_resample_multif0():
     actual_freqs4 = mir_eval.multipitch.resample_multipitch(
         empty_times, empty_freqs, target_times1)
 
+    times = np.array([0.00, 0.03, 0.07])
+    freqs = [
+        np.array([200.]),
+        np.array([400.]),
+        np.array([200.])
+    ]
+    target_times5 = np.array([0.00, 0.01, 0.02, 0.03,
+                              0.04, 0.05, 0.06, 0.07])
+    target_times6 = np.array([0.00, 0.007, 0.015, 0.023,
+                              0.03, 0.04, 0.05, 0.06, 0.07])
+
+    expected_freqs5 = [
+        np.array([200.]),
+        np.array([]),
+        np.array([]),
+        np.array([400.]),
+        np.array([]),
+        np.array([]),
+        np.array([]),
+        np.array([200.])
+    ]
+    expected_freqs6 = [
+        np.array([200.]),
+        np.array([200.]),
+        np.array([]),
+        np.array([400.]),
+        np.array([400.]),
+        np.array([]),
+        np.array([]),
+        np.array([]),
+        np.array([200.])
+    ]
+
+    actual_freqs5 = mir_eval.multipitch.resample_multipitch(
+        times, freqs, target_times5, 0.005)
+    actual_freqs6 = mir_eval.multipitch.resample_multipitch(
+        times, freqs, target_times6, 0.015)
+
     assert __frequencies_equal(actual_freqs1, expected_freqs1)
     assert __frequencies_equal(actual_freqs2, expected_freqs2)
     assert __frequencies_equal(actual_freqs3, expected_freqs3)
     assert __frequencies_equal(actual_freqs4, expected_freqs4)
+    assert __frequencies_equal(actual_freqs5, expected_freqs5)
+    assert __frequencies_equal(actual_freqs6, expected_freqs6)
 
 
 def test_frequencies_to_midi():


### PR DESCRIPTION
Using the current functionality, if I try to resample the following pitch list,

![image](https://user-images.githubusercontent.com/33099118/107863126-93582100-6e1f-11eb-9c46-cbc456a2a5b8.png)

which has no empty pitch observations (taken directly from a JAMS file), I get the following:

![image](https://user-images.githubusercontent.com/33099118/107863202-390b9000-6e20-11eb-9f14-21cbf61c017d.png)

With the changes, specifying a tolerance of 50 ms, I get the following:

![image](https://user-images.githubusercontent.com/33099118/107863215-57718b80-6e20-11eb-889d-f49adf7250dc.png)

A good rule of thumb would be setting the tolerance (if you want to use it) to twice the minimum timing difference in your pitch list.