### PR TITLE
Add docs for alignment metrics

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -79,6 +79,14 @@ Finally, each task submodule also includes functions for common data pre-process
 
 The following subsections document each submodule.
 
+:mod:`mir_eval.alignment`
+--------------------
+.. automodule:: mir_eval.alignment
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :member-order: bysource
+
 :mod:`mir_eval.beat`
 --------------------
 .. automodule:: mir_eval.beat


### PR DESCRIPTION
Apparently the alignment functions don't show up in the docs yet. I added the module to index.rst
Please check if the docs generate properly now and merge in that case. Thanks!