### PR TITLE
Set precision for np.int and np.float

### DIFF
--- a/mir_eval/beat.py
+++ b/mir_eval/beat.py
@@ -386,14 +386,14 @@ def p_score(reference_beats,
     estimated_beats = np.array(estimated_beats - offset)
     reference_beats = np.array(reference_beats - offset)
     # Get the largest time index
-    end_point = np.int(np.ceil(np.max([np.max(estimated_beats),
-                                       np.max(reference_beats)])))
+    end_point = np.int64(np.ceil(np.max([np.max(estimated_beats),
+                                         np.max(reference_beats)])))
     # Make impulse trains with impulses at beat locations
     reference_train = np.zeros(end_point*sampling_rate + 1)
-    beat_indices = np.ceil(reference_beats*sampling_rate).astype(np.int)
+    beat_indices = np.ceil(reference_beats*sampling_rate).astype(np.int64)
     reference_train[beat_indices] = 1.0
     estimated_train = np.zeros(end_point*sampling_rate + 1)
-    beat_indices = np.ceil(estimated_beats*sampling_rate).astype(np.int)
+    beat_indices = np.ceil(estimated_beats*sampling_rate).astype(np.int64)
     estimated_train[beat_indices] = 1.0
     # Window size to take the correlation over
     # defined as .2*median(inter-annotation-intervals)

--- a/mir_eval/chord.py
+++ b/mir_eval/chord.py
@@ -510,7 +510,7 @@ def encode(chord_label, reduce_extended_chords=False,
         semitone_bitmap += scale_degree_to_bitmap(scale_degree,
                                                   reduce_extended_chords)
 
-    semitone_bitmap = (semitone_bitmap > 0).astype(np.int)
+    semitone_bitmap = (semitone_bitmap > 0).astype(np.int64)
     if not semitone_bitmap[bass_number] and strict_bass_intervals:
         raise InvalidChordException(
             "Given bass scale degree is absent from this chord: "
@@ -544,8 +544,8 @@ def encode_many(chord_labels, reduce_extended_chords=False):
 
     """
     num_items = len(chord_labels)
-    roots, basses = np.zeros([2, num_items], dtype=np.int)
-    semitones = np.zeros([num_items, 12], dtype=np.int)
+    roots, basses = np.zeros([2, num_items], dtype=np.int64)
+    semitones = np.zeros([num_items, 12], dtype=np.int64)
     local_cache = dict()
     for i, label in enumerate(chord_labels):
         result = local_cache.get(label, None)
@@ -749,7 +749,7 @@ def thirds(reference_labels, estimated_labels):
 
     eq_roots = ref_roots == est_roots
     eq_thirds = ref_semitones[:, 3] == est_semitones[:, 3]
-    comparison_scores = (eq_roots * eq_thirds).astype(np.float)
+    comparison_scores = (eq_roots * eq_thirds).astype(np.float64)
 
     # Ignore 'X' chords
     comparison_scores[np.any(ref_semitones < 0, axis=1)] = -1.0
@@ -797,7 +797,7 @@ def thirds_inv(reference_labels, estimated_labels):
     eq_root = ref_roots == est_roots
     eq_bass = ref_bass == est_bass
     eq_third = ref_semitones[:, 3] == est_semitones[:, 3]
-    comparison_scores = (eq_root * eq_third * eq_bass).astype(np.float)
+    comparison_scores = (eq_root * eq_third * eq_bass).astype(np.float64)
 
     # Ignore 'X' chords
     comparison_scores[np.any(ref_semitones < 0, axis=1)] = -1.0
@@ -845,7 +845,7 @@ def triads(reference_labels, estimated_labels):
     eq_roots = ref_roots == est_roots
     eq_semitones = np.all(
         np.equal(ref_semitones[:, :8], est_semitones[:, :8]), axis=1)
-    comparison_scores = (eq_roots * eq_semitones).astype(np.float)
+    comparison_scores = (eq_roots * eq_semitones).astype(np.float64)
 
     # Ignore 'X' chords
     comparison_scores[np.any(ref_semitones < 0, axis=1)] = -1.0
@@ -894,7 +894,7 @@ def triads_inv(reference_labels, estimated_labels):
     eq_basses = ref_bass == est_bass
     eq_semitones = np.all(
         np.equal(ref_semitones[:, :8], est_semitones[:, :8]), axis=1)
-    comparison_scores = (eq_roots * eq_semitones * eq_basses).astype(np.float)
+    comparison_scores = (eq_roots * eq_semitones * eq_basses).astype(np.float64)
 
     # Ignore 'X' chords
     comparison_scores[np.any(ref_semitones < 0, axis=1)] = -1.0
@@ -941,7 +941,7 @@ def tetrads(reference_labels, estimated_labels):
 
     eq_roots = ref_roots == est_roots
     eq_semitones = np.all(np.equal(ref_semitones, est_semitones), axis=1)
-    comparison_scores = (eq_roots * eq_semitones).astype(np.float)
+    comparison_scores = (eq_roots * eq_semitones).astype(np.float64)
 
     # Ignore 'X' chords
     comparison_scores[np.any(ref_semitones < 0, axis=1)] = -1.0
@@ -989,7 +989,7 @@ def tetrads_inv(reference_labels, estimated_labels):
     eq_roots = ref_roots == est_roots
     eq_basses = ref_bass == est_bass
     eq_semitones = np.all(np.equal(ref_semitones, est_semitones), axis=1)
-    comparison_scores = (eq_roots * eq_semitones * eq_basses).astype(np.float)
+    comparison_scores = (eq_roots * eq_semitones * eq_basses).astype(np.float64)
 
     # Ignore 'X' chords
     comparison_scores[np.any(ref_semitones < 0, axis=1)] = -1.0
@@ -1035,7 +1035,7 @@ def root(reference_labels, estimated_labels):
     validate(reference_labels, estimated_labels)
     ref_roots, ref_semitones = encode_many(reference_labels, False)[:2]
     est_roots = encode_many(estimated_labels, False)[0]
-    comparison_scores = (ref_roots == est_roots).astype(np.float)
+    comparison_scores = (ref_roots == est_roots).astype(np.float64)
 
     # Ignore 'X' chords
     comparison_scores[np.any(ref_semitones < 0, axis=1)] = -1.0
@@ -1087,7 +1087,7 @@ def mirex(reference_labels, estimated_labels):
     eq_chroma = (ref_chroma * est_chroma).sum(axis=-1)
 
     # Chroma matching for set bits
-    comparison_scores = (eq_chroma >= min_intersection).astype(np.float)
+    comparison_scores = (eq_chroma >= min_intersection).astype(np.float64)
 
     # No-chord matching; match -1 roots, SKIP_CHORDS dropped next
     no_root = np.logical_and(ref_data[0] == -1, est_data[0] == -1)
@@ -1150,7 +1150,7 @@ def majmin(reference_labels, estimated_labels):
     eq_root = ref_roots == est_roots
     eq_quality = np.all(np.equal(ref_semitones[:, :8],
                                  est_semitones[:, :8]), axis=1)
-    comparison_scores = (eq_root * eq_quality).astype(np.float)
+    comparison_scores = (eq_root * eq_quality).astype(np.float64)
 
     # Test for Major / Minor / No-chord
     is_maj = np.all(np.equal(ref_semitones[:, :8], maj_semitones), axis=1)
@@ -1217,7 +1217,7 @@ def majmin_inv(reference_labels, estimated_labels):
     eq_root_bass = (ref_roots == est_roots) * (ref_bass == est_bass)
     eq_semitones = np.all(np.equal(ref_semitones[:, :8],
                                    est_semitones[:, :8]), axis=1)
-    comparison_scores = (eq_root_bass * eq_semitones).astype(np.float)
+    comparison_scores = (eq_root_bass * eq_semitones).astype(np.float64)
 
     # Test for Major / Minor / No-chord
     is_maj = np.all(np.equal(ref_semitones[:, :8], maj_semitones), axis=1)
@@ -1280,7 +1280,7 @@ def sevenths(reference_labels, estimated_labels):
 
     eq_root = ref_roots == est_roots
     eq_semitones = np.all(np.equal(ref_semitones, est_semitones), axis=1)
-    comparison_scores = (eq_root * eq_semitones).astype(np.float)
+    comparison_scores = (eq_root * eq_semitones).astype(np.float64)
 
     # Test for reference chord inclusion
     is_valid = np.array([np.all(np.equal(ref_semitones, semitones), axis=1)
@@ -1335,7 +1335,7 @@ def sevenths_inv(reference_labels, estimated_labels):
 
     eq_roots_basses = (ref_roots == est_roots) * (ref_basses == est_basses)
     eq_semitones = np.all(np.equal(ref_semitones, est_semitones), axis=1)
-    comparison_scores = (eq_roots_basses * eq_semitones).astype(np.float)
+    comparison_scores = (eq_roots_basses * eq_semitones).astype(np.float64)
 
     # Test for Major / Minor / No-chord
     is_valid = np.array([np.all(np.equal(ref_semitones, semitones), axis=1)

--- a/mir_eval/display.py
+++ b/mir_eval/display.py
@@ -532,7 +532,7 @@ def pitch(times, frequencies, midi=False, unvoiced=False, ax=None, **kwargs):
 
     # First, segment into contiguously voiced contours
     frequencies, voicings = freq_to_voicing(np.asarray(frequencies,
-                                                       dtype=np.float))
+                                                       dtype=np.float64))
     voicings = voicings.astype(bool)
 
     # Here are all the change-points
@@ -638,7 +638,7 @@ def multipitch(times, frequencies, midi=False, unvoiced=False, ax=None,
         if not len(freqs):
             continue
 
-        freqs, voicings = freq_to_voicing(np.asarray(freqs, dtype=np.float))
+        freqs, voicings = freq_to_voicing(np.asarray(freqs, dtype=np.float64))
 
         # Discard all 0-frequency measurements
         idx = freqs > 0

--- a/mir_eval/segment.py
+++ b/mir_eval/segment.py
@@ -540,7 +540,7 @@ def _contingency_matrix(reference_indices, estimated_indices):
     return scipy.sparse.coo_matrix((np.ones(ref_class_idx.shape[0]),
                                     (ref_class_idx, est_class_idx)),
                                    shape=(n_ref_classes, n_est_classes),
-                                   dtype=np.int).toarray()
+                                   dtype=np.int64).toarray()
 
 
 def _adjusted_rand_index(reference_indices, estimated_indices):
@@ -720,7 +720,7 @@ def _entropy(labels):
     if len(labels) == 0:
         return 1.0
     label_idx = np.unique(labels, return_inverse=True)[1]
-    pi = np.bincount(label_idx).astype(np.float)
+    pi = np.bincount(label_idx).astype(np.float64)
     pi = pi[pi > 0]
     pi_sum = np.sum(pi)
     # log(a / b) should be calculated as log(a) - log(b) for

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -19,9 +19,9 @@ SCORES_GLOB = 'data/beat/output*.json'
 
 def test_trim_beats():
     # Construct dummy beat times [0., 1., ...]
-    dummy_beats = np.arange(10, dtype=np.float)
+    dummy_beats = np.arange(10, dtype=np.float64)
     # We expect trim_beats to remove all beats < 5s
-    expected_beats = np.arange(5, 10, dtype=np.float)
+    expected_beats = np.arange(5, 10, dtype=np.float64)
     assert np.allclose(mir_eval.beat.trim_beats(dummy_beats), expected_beats)
 
 
@@ -51,7 +51,7 @@ def __unit_test_beat_function(metric):
     nose.tools.assert_raises(ValueError, metric, beats, beats)
 
     # Valid beats which are the same produce a score of 1 for all metrics
-    beats = np.arange(10, dtype=np.float)
+    beats = np.arange(10, dtype=np.float64)
     assert np.allclose(metric(beats, beats), 1)
 
 

--- a/tests/test_onset.py
+++ b/tests/test_onset.py
@@ -43,7 +43,7 @@ def __unit_test_onset_function(metric):
     nose.tools.assert_raises(ValueError, metric, onsets, onsets)
 
     # Valid onsets which are the same produce a score of 1 for all metrics
-    onsets = np.arange(10, dtype=np.float)
+    onsets = np.arange(10, dtype=np.float64)
     assert np.allclose(metric(onsets, onsets), 1)
 
 


### PR DESCRIPTION
As per https://numpy.org/devdocs/release/1.24.0-notes.html#expired-deprecations these aliases are deprecated and now cause errors.