### PR TITLE
Drop Python 2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,8 +15,6 @@ If you're looking for the mir_eval web service, which you can use to run mir_eva
 Dependencies:
 
 * `Scipy/Numpy <http://www.scipy.org/>`_
-* future
-* six
 
 If you use mir_eval in a research project, please cite the following paper:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,8 +49,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'mir_eval'
-copyright = u'2014, Colin Raffel et al.'
+project = 'mir_eval'
+copyright = '2014, Colin Raffel et al.'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -202,8 +202,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  ('index', 'mir_eval.tex', u'mir\\_eval Documentation',
-   u'Colin Raffel et al.', 'manual'),
+  ('index', 'mir_eval.tex', 'mir\\_eval Documentation',
+   'Colin Raffel et al.', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -232,8 +232,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'mir_eval', u'mir_eval Documentation',
-     [u'Colin Raffel et al.'], 1)
+    ('index', 'mir_eval', 'mir_eval Documentation',
+     ['Colin Raffel et al.'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -246,8 +246,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'mir_eval', u'mir_eval Documentation',
-   u'Colin Raffel et al.', 'mir_eval', 'One line description of project.',
+  ('index', 'mir_eval', 'mir_eval Documentation',
+   'Colin Raffel et al.', 'mir_eval', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/mir_eval/io.py
+++ b/mir_eval/io.py
@@ -646,10 +646,10 @@ def load_ragged_time_series(filename, dtype=float, delimiter=r'\s+',
             try:
                 converted_time = float(data[0])
             except (TypeError, ValueError) as exe:
-                six.raise_from(ValueError("Couldn't convert value {} using {} "
-                                          "found at {}:{:d}:\n\t{}".format(
-                                            data[0], float.__name__,
-                                            filename, row, line)), exe)
+                raise ValueError("Couldn't convert value {} using {} "
+                                 "found at {}:{:d}:\n\t{}".format(
+                                   data[0], float.__name__,
+                                   filename, row, line)) from exe
             times.append(converted_time)
 
             # cast values to a numpy array. time stamps with no values are cast
@@ -657,10 +657,10 @@ def load_ragged_time_series(filename, dtype=float, delimiter=r'\s+',
             try:
                 converted_value = np.array(data[1:], dtype=dtype)
             except (TypeError, ValueError) as exe:
-                six.raise_from(ValueError("Couldn't convert value {} using {} "
-                                          "found at {}:{:d}:\n\t{}".format(
-                                            data[1:], dtype.__name__,
-                                            filename, row, line)), exe)
+                raise ValueError("Couldn't convert value {} using {} "
+                                 "found at {}:{:d}:\n\t{}".format(
+                                   data[1:], dtype.__name__,
+                                   filename, row, line)) from exe
             values.append(converted_value)
 
     return np.array(times), values

--- a/mir_eval/io.py
+++ b/mir_eval/io.py
@@ -7,7 +7,6 @@ import numpy as np
 import re
 import warnings
 import scipy.io.wavfile
-import six
 
 from . import util
 from . import key

--- a/mir_eval/io.py
+++ b/mir_eval/io.py
@@ -26,7 +26,7 @@ def _open(file_or_str, **kwargs):
     '''
     if hasattr(file_or_str, 'read'):
         yield file_or_str
-    elif isinstance(file_or_str, six.string_types):
+    elif isinstance(file_or_str, str):
         with open(file_or_str, **kwargs) as file_desc:
             yield file_desc
     else:

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -456,7 +456,7 @@ def bss_eval_images(reference_sources, estimated_sources,
                     _bss_image_crit(s_true, e_spat, e_interf, e_artif)
 
         # select the best ordering
-        perms = list(itertools.permutations(range(nsrc)))
+        perms = list(itertools.permutations(list(range(nsrc))))
         mean_sir = np.empty(len(perms))
         dum = np.arange(nsrc)
         for (i, perm) in enumerate(perms):

--- a/mir_eval/util.py
+++ b/mir_eval/util.py
@@ -861,16 +861,13 @@ def has_kwargs(function):
     False otherwise.
     '''
 
-    if six.PY2:
-        return inspect.getargspec(function).keywords is not None
-    else:
-        sig = inspect.signature(function)
+    sig = inspect.signature(function)
 
-        for param in list(sig.parameters.values()):
-            if param.kind == param.VAR_KEYWORD:
-                return True
+    for param in list(sig.parameters.values()):
+        if param.kind == param.VAR_KEYWORD:
+            return True
 
-        return False
+    return False
 
 
 def filter_kwargs(_function, *args, **kwargs):

--- a/mir_eval/util.py
+++ b/mir_eval/util.py
@@ -866,7 +866,7 @@ def has_kwargs(function):
     else:
         sig = inspect.signature(function)
 
-        for param in sig.parameters.values():
+        for param in list(sig.parameters.values()):
             if param.kind == param.VAR_KEYWORD:
                 return True
 

--- a/mir_eval/util.py
+++ b/mir_eval/util.py
@@ -5,7 +5,6 @@ submodules, such as preprocessing, validation, and common computations.
 
 import os
 import inspect
-import six
 
 import numpy as np
 

--- a/mir_eval/util.py
+++ b/mir_eval/util.py
@@ -890,7 +890,7 @@ def filter_kwargs(_function, *args, **kwargs):
         return _function(*args, **kwargs)
 
     # Get the list of function arguments
-    func_code = six.get_function_code(_function)
+    func_code = _function.__code__
     function_args = func_code.co_varnames[:func_code.co_argcount]
     # Construct a dict of those kwargs which appear in the function
     filtered_kwargs = {}

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,6 @@ setup(
                     'pytest-cov',
                     'pytest-mpl',
                     'nose']
-    }
+    },
+    python_requires='>=3',
 )

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
         'Development Status :: 5 - Production/Stable',
         "Intended Audience :: Developers",
         "Topic :: Multimedia :: Sound/Audio :: Analysis",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
     ],
     keywords='audio music mir dsp',

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,6 @@ setup(
     install_requires=[
         'numpy >= 1.7.0',
         'scipy >= 1.0.0',
-        'future',
-        'six'
     ],
     extras_require={
         'display': ['matplotlib>=1.5.0'],

--- a/tests/generate_data.py
+++ b/tests/generate_data.py
@@ -19,7 +19,7 @@ So, for example, if you'd like to generate data for onset and melody,run
     ./generate_data.py onset melody
 '''
 
-from __future__ import print_function
+
 import mir_eval
 import glob
 import json

--- a/tests/test_chord.py
+++ b/tests/test_chord.py
@@ -184,7 +184,7 @@ def test_encode():
                           [1, 0, 0, 1, 1, 0, 0, 1, 0, 0, 1, 0]]
     expected_bass = [7, 0, 4, 3]
 
-    args = zip(labels, expected_roots, expected_intervals, expected_bass)
+    args = list(zip(labels, expected_roots, expected_intervals, expected_bass))
     for label, e_root, e_interval, e_bass in args:
         yield (__check_encode, label, e_root, e_interval, e_bass, False, False)
 


### PR DESCRIPTION
IIRC `future` and `six` were for the Python 2 -> 3 migration. As Python 2 has passed EOL it's probably not necessary to mention it anymore.