### PR TITLE
Add release workflow for GitHub Actions based PyPI package releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Build and publish Python packages to PyPI
+
+on:
+  workflow_dispatch:
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - "3.8"
+          - "3.9"
+          - "3.10"
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install build tool
+        run: pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Upload package as build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: package
+          path: dist/
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: pypi
+      url: https://pypi.org/p/mir_eval
+    permissions:
+      id-token: write
+    steps:
+      - name: Collect packages to release
+        uses: actions/download-artifact@v3
+        with:
+          name: package
+          path: dist/
+
+      - name: Publish packages to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
### What?
Introduce a package release workflow for building and distributing `mir_eval` to PyPI.

### Install workflow on PyPI
Login to https://pypi.org/manage/account/publishing/ and fill in GitHub.com repo details under the `mir_eval` package settings.

### Usage of workflow on GitHub
1. Update package version in Python code.
2. Create a GitHub Releases release as repo owner here: https://github.com/craffel/mir_eval/releases
3. Watch the GitHub Actions workflow run. Once ✅ the newly built package should be on PyPI here https://pypi.org/project/mir_eval