### PR TITLE
Fix length error in sonify.time_frequency

### DIFF
--- a/mir_eval/sonify.py
+++ b/mir_eval/sonify.py
@@ -203,7 +203,7 @@ def time_frequency(
         t_in = max(sample_intervals[0][0], 0)
         t_out = min(sample_intervals[-1][-1], length)
         signal = gram_interpolator(np.arange(t_in, t_out))
-        output[:len(signal)] += wave[:len(signal)] * signal
+        output[t_in:t_out] += wave[:len(signal)] * signal
 
     # Normalize, but only if there's non-zero values
     norm = np.abs(output).max()

--- a/mir_eval/sonify.py
+++ b/mir_eval/sonify.py
@@ -203,7 +203,7 @@ def time_frequency(
         t_in = max(sample_intervals[0][0], 0)
         t_out = min(sample_intervals[-1][-1], length)
         signal = gram_interpolator(np.arange(t_in, t_out))
-        output[t_in:t_out] += wave[:len(signal)] * signal
+        output[t_in:t_out] += wave[: len(signal)] * signal
 
     # Normalize, but only if there's non-zero values
     norm = np.abs(output).max()

--- a/mir_eval/sonify.py
+++ b/mir_eval/sonify.py
@@ -200,13 +200,10 @@ def time_frequency(
 
         # Create the time-varying scaling for the entire time interval by the piano roll
         # magnitude and add to the accumulating waveform.
-        # FIXME: this logic is broken when length
-        # does not match the final sample interval
-        output += wave[:length] * gram_interpolator(
-            np.arange(
-                max(sample_intervals[0][0], 0), min(sample_intervals[-1][-1], length)
-            )
-        )
+        t_in = max(sample_intervals[0][0], 0)
+        t_out = min(sample_intervals[-1][-1], length)
+        signal = gram_interpolator(np.arange(t_in, t_out))
+        output[:len(signal)] += wave[:len(signal)] * signal
 
     # Normalize, but only if there's non-zero values
     norm = np.abs(output).max()

--- a/tests/test_sonify.py
+++ b/tests/test_sonify.py
@@ -28,6 +28,8 @@ def test_time_frequency(fs):
         fs,
     )
     assert len(signal) == 10 * fs
+
+    # Make one longer
     signal = mir_eval.sonify.time_frequency(
         np.random.standard_normal((100, 1000)),
         np.arange(1, 101),
@@ -36,6 +38,16 @@ def test_time_frequency(fs):
         length=fs * 11,
     )
     assert len(signal) == 11 * fs
+
+    # Make one shorter
+    signal = mir_eval.sonify.time_frequency(
+        np.random.standard_normal((100, 1000)),
+        np.arange(1, 101),
+        np.linspace(0, 10, 1000),
+        fs,
+        length=fs * 5,
+    )
+    assert len(signal) == 5 * fs
 
 
 @pytest.mark.parametrize("fs", [8000, 44100])

--- a/tests/test_sonify.py
+++ b/tests/test_sonify.py
@@ -54,8 +54,6 @@ def test_chroma(fs):
 
 
 @pytest.mark.parametrize("fs", [8000, 44100])
-# FIXME: #371
-@pytest.mark.skip(reason="Skipped until #371 is fixed")
 def test_chords(fs):
     intervals = np.array([np.arange(10), np.arange(1, 11)]).T
     signal = mir_eval.sonify.chords(


### PR DESCRIPTION
This PR fixes #371 by separating out the slicing logic for time_frequency generation.

I've unskipped the test that was previously failing and things seem good to go.