### PR TITLE
More efficient chord validation

### DIFF
--- a/mir_eval/chord.py
+++ b/mir_eval/chord.py
@@ -340,6 +340,12 @@ def reduce_extended_quality(quality):
 
 
 # --- Chord Label Parsing ---
+# This monster regexp is pulled from the JAMS chord namespace,
+# which is in turn derived from the context-free grammar of
+# Harte et al., 2005.
+CHORD_RE = re.compile(
+    r"""^((N|X)|(([A-G](b*|#*))((:(maj|min|dim|aug|1|5|sus2|sus4|maj6|min6|7|maj7|min7|dim7|hdim7|minmaj7|aug7|9|maj9|min9|11|maj11|min11|13|maj13|min13)(\((\*?((b*|#*)([1-9]|1[0-3]?))(,\*?((b*|#*)([1-9]|1[0-3]?)))*)\))?)|(:\((\*?((b*|#*)([1-9]|1[0-3]?))(,\*?((b*|#*)([1-9]|1[0-3]?)))*)\)))?((/((b*|#*)([1-9]|1[0-3]?)))?)?))$"""
+)  # nopep8
 def validate_chord_label(chord_label):
     """Test for well-formedness of a chord label.
 
@@ -348,15 +354,7 @@ def validate_chord_label(chord_label):
     chord_label : str
         Chord label to validate.
     """
-    # This monster regexp is pulled from the JAMS chord namespace,
-    # which is in turn derived from the context-free grammar of
-    # Harte et al., 2005.
-
-    pattern = re.compile(
-        r"""^((N|X)|(([A-G](b*|#*))((:(maj|min|dim|aug|1|5|sus2|sus4|maj6|min6|7|maj7|min7|dim7|hdim7|minmaj7|aug7|9|maj9|min9|11|maj11|min11|13|maj13|min13)(\((\*?((b*|#*)([1-9]|1[0-3]?))(,\*?((b*|#*)([1-9]|1[0-3]?)))*)\))?)|(:\((\*?((b*|#*)([1-9]|1[0-3]?))(,\*?((b*|#*)([1-9]|1[0-3]?)))*)\)))?((/((b*|#*)([1-9]|1[0-3]?)))?)?))$"""
-    )  # nopep8
-
-    if not pattern.match(chord_label):
+    if not CHORD_RE.match(chord_label):
         raise InvalidChordException("Invalid chord label: " "{}".format(chord_label))
     pass
 

--- a/mir_eval/chord.py
+++ b/mir_eval/chord.py
@@ -346,6 +346,8 @@ def reduce_extended_quality(quality):
 CHORD_RE = re.compile(
     r"""^((N|X)|(([A-G](b*|#*))((:(maj|min|dim|aug|1|5|sus2|sus4|maj6|min6|7|maj7|min7|dim7|hdim7|minmaj7|aug7|9|maj9|min9|11|maj11|min11|13|maj13|min13)(\((\*?((b*|#*)([1-9]|1[0-3]?))(,\*?((b*|#*)([1-9]|1[0-3]?)))*)\))?)|(:\((\*?((b*|#*)([1-9]|1[0-3]?))(,\*?((b*|#*)([1-9]|1[0-3]?)))*)\)))?((/((b*|#*)([1-9]|1[0-3]?)))?)?))$"""
 )  # nopep8
+
+
 def validate_chord_label(chord_label):
     """Test for well-formedness of a chord label.
 


### PR DESCRIPTION
Pulling this change out of PR #377

The chord validator was compiling a monster regexp on each call, which is pretty wasteful.  This PR just lifts that regexp precompilation up to the module so it can be reused.  I belive this was the main inefficiency behind issue #341 .

There should be no functional changes here, so as long as it passes linting and CI I'm happy to merge.