### PR TITLE
Pitch contour sonification supports nans

### DIFF
--- a/mir_eval/sonify.py
+++ b/mir_eval/sonify.py
@@ -224,7 +224,7 @@ def pitch_contour(
         time indices for each frequency measurement, in seconds
     frequencies : np.ndarray
         frequency measurements, in Hz.
-        Non-positive measurements will be interpreted as un-voiced samples.
+        Non-positive measurements or NaNs will be interpreted as un-voiced samples.
     fs : int
         desired sampling rate of the output signal
     amplitudes : np.ndarray
@@ -252,6 +252,8 @@ def pitch_contour(
     # Squash the negative frequencies.
     # wave(0) = 0, so clipping here will un-voice the corresponding instants
     frequencies = np.maximum(frequencies, 0.0)
+    # Convert nans to zeros to unvoice
+    frequencies = np.nan_to_num(frequencies, copy=False)
 
     # Build a frequency interpolator
     f_interp = interp1d(


### PR DESCRIPTION
Fixes #332

This PR works be replacing nan-values by 0 in the frequency array prior to interpolation, thereby replicating the existing logic for unvoicing certain frames.

This now lets us use nan to represent unvoiced frames, which is the default behavior for (eg) librosa's pyin implementation.

I don't think we need specific additional tests here, as the change is minimal and pretty obvious when you see it.