### PR TITLE
deprecating separation module

### DIFF
--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -1,5 +1,11 @@
 # -*- coding: utf-8 -*-
 """
+.. warning::
+    The mir_eval.separation module is deprecated in mir_eval version 0.8, and will be removed.
+    We recommend that you migrate your code to use an alternative package such as sigsep-museval
+    https://sigsep.github.io/sigsep-mus-eval/
+    
+
 Source separation algorithms attempt to extract recordings of individual
 sources from a recording of a mixture of sources.  Evaluation methods for
 source separation compare the extracted sources from reference sources and
@@ -141,6 +147,7 @@ def _any_source_silent(sources):
     )
 
 
+@util.deprecated(version="0.8", version_removed="0.9")
 def bss_eval_sources(reference_sources, estimated_sources, compute_permutation=True):
     """
     Ordering and measurement of the separation quality for estimated source
@@ -251,6 +258,7 @@ def bss_eval_sources(reference_sources, estimated_sources, compute_permutation=T
         return (sdr, sir, sar, popt)
 
 
+@util.deprecated(version="0.8", version_removed="0.9")
 def bss_eval_sources_framewise(
     reference_sources,
     estimated_sources,
@@ -362,6 +370,7 @@ def bss_eval_sources_framewise(
     return sdr, sir, sar, perm
 
 
+@util.deprecated(version="0.8", version_removed="0.9")
 def bss_eval_images(reference_sources, estimated_sources, compute_permutation=True):
     """Compute the bss_eval_images function from the
     BSS_EVAL Matlab toolbox.
@@ -496,6 +505,7 @@ def bss_eval_images(reference_sources, estimated_sources, compute_permutation=Tr
         return (sdr, isr, sir, sar, popt)
 
 
+@util.deprecated(version="0.8", version_removed="0.9")
 def bss_eval_images_framewise(
     reference_sources,
     estimated_sources,
@@ -841,6 +851,7 @@ def _safe_db(num, den):
     return 10 * np.log10(num / den)
 
 
+@util.deprecated(version="0.8", version_removed="0.9")
 def evaluate(reference_sources, estimated_sources, **kwargs):
     """Compute all metrics for the given reference and estimated signals.
 

--- a/mir_eval/util.py
+++ b/mir_eval/util.py
@@ -5,6 +5,8 @@ such as preprocessing, validation, and common computations.
 
 import os
 import inspect
+import warnings
+from decorator import decorator
 
 import numpy as np
 
@@ -939,3 +941,22 @@ def midi_to_hz(midi):
         Frequency/frequencies in Hz corresponding to `midi`
     """
     return 440.0 * (2.0 ** ((midi - 69.0) / 12.0))
+
+
+def deprecated(*, version, version_removed):
+    """Mark a function as deprecated.
+
+    Using the decorated (old) function will result in a warning.
+    """
+
+    def __wrapper(func, *args, **kwargs):
+        """Warn the user, and then proceed."""
+        warnings.warn(
+            f"{func.__module__}.{func.__name__}\n\tDeprecated as of mir_eval version {version}."
+            f"\n\tIt will be removed in mir_eval version {version_removed}.",
+            category=FutureWarning,
+            stacklevel=3,  # Would be 2, but the decorator adds a level
+        )
+        return func(*args, **kwargs)
+
+    return decorator(__wrapper)

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,13 +48,13 @@ keywords = audio music mir dsp
 install_requires =
     numpy >= 1.15.4
     scipy >= 1.4.0
+    decorator
 
 [options.extras_require]
 display = 
     matplotlib >= 3.3.0
 testing = 
     matplotlib >= 3.3.0
-    decorator
     pytest
     pytest-cov
     pytest-mpl

--- a/tests/test_separation.py
+++ b/tests/test_separation.py
@@ -119,8 +119,9 @@ def test_empty_input(metric):
         # And that the metric returns empty arrays
         assert np.allclose(metric(*args), np.array([]))
 
-        assert "reference_sources is empty" in str(record[0].message)
-        assert "estimated_sources is empty" in str(record[1].message)
+        # These warning counters are now offset by 1 because of the deprecation message
+        assert "reference_sources is empty" in str(record[1].message)
+        assert "estimated_sources is empty" in str(record[2].message)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR deprecates the separation module.

Question for @faroit - is sigsep-museval the best replacement to recommend here?

Question for @craffel - should we disable tests on the separation module?  They've always been finnicky and the vast majority of build time.  If we're deprecating the module anyway, I could see some benefit to disabling these tests.