### PR TITLE
Rename testing -> tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,8 @@ on:
       - main
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: True
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: True
 
 jobs:
   test:
@@ -34,7 +34,7 @@ jobs:
             envfile: ".github/environment-minimal.yml"
             channel-priority: "flexible"
             name: "Minimal dependencies"
-          
+
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -58,7 +58,7 @@ jobs:
 
       - name: Install package in development mode
         shell: bash -l {0}
-        run: python -m pip install --upgrade-strategy=only-if-needed -e .[display,testing]
+        run: python -m pip install --upgrade-strategy=only-if-needed -e .[display,tests]
 
       - name: Log installed packages for debugging
         shell: bash -l {0}

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,9 +50,9 @@ install_requires =
     scipy >= 1.4.0
 
 [options.extras_require]
-display = 
+display =
     matplotlib >= 3.3.0
-testing = 
+tests =
     matplotlib >= 3.3.0
     decorator
     pytest


### PR DESCRIPTION
Very minor DX thing but `pip install -e ".[tests]"` is what my brain assumed and got tripped up on just now when attempting to fix a matplotlib deprecation.

Might be nice to have the same convention as e.g. librosa which also calls the test dependencies "tests" and not "testing".