### PR TITLE
Fix ImportError

### DIFF
--- a/mir_eval/display.py
+++ b/mir_eval/display.py
@@ -12,7 +12,7 @@ from matplotlib.patches import Rectangle
 from matplotlib.ticker import FuncFormatter, MultipleLocator
 from matplotlib.ticker import Formatter
 from matplotlib.colors import LinearSegmentedColormap, LogNorm, ColorConverter
-from matplotlib.collections import BrokenBarHCollection
+from matplotlib.collections import PolyCollection as BrokenBarHCollection
 from matplotlib.transforms import Bbox, TransformedBbox
 
 from .melody import freq_to_voicing
@@ -264,7 +264,7 @@ def labeled_intervals(
 
     **kwargs
         Additional keyword arguments to pass to
-        `matplotlib.collection.BrokenBarHCollection`.
+        `matplotlib.collection.PolyCollection`.
 
     Returns
     -------

--- a/mir_eval/display.py
+++ b/mir_eval/display.py
@@ -183,18 +183,15 @@ def segments(
         seg_map[lab].pop("label", None)
 
         if text:
-            bbox = Bbox.from_extents(ival[0], base, ival[1], height)
-            tbbox = TransformedBbox(bbox, transform)
             ann = ax.annotate(
                 lab,
                 xy=(ival[0], height),
                 xycoords=transform,
                 xytext=(8, -10),
                 textcoords="offset points",
-                clip_path=rect,
-                clip_box=tbbox,
                 **text_kw
             )
+            ann.set_clip_path(rect)
 
     return ax
 

--- a/mir_eval/display.py
+++ b/mir_eval/display.py
@@ -12,7 +12,6 @@ from matplotlib.patches import Rectangle
 from matplotlib.ticker import FuncFormatter, MultipleLocator
 from matplotlib.ticker import Formatter
 from matplotlib.colors import LinearSegmentedColormap, LogNorm, ColorConverter
-from matplotlib.collections import PolyCollection as BrokenBarHCollection
 from matplotlib.transforms import Bbox, TransformedBbox
 
 from .melody import freq_to_voicing

--- a/mir_eval/separation.py
+++ b/mir_eval/separation.py
@@ -837,7 +837,7 @@ def _safe_db(num, den):
     be 0.
     """
     if den == 0:
-        return np.Inf
+        return np.inf
     return 10 * np.log10(num / den)
 
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -151,7 +151,7 @@ def test_display_labeled_intervals_compare_noextend():
         est_int, est_labels, extend_labels=False, alpha=0.5, label="Estimate"
     )
 
-    plt.legend()
+    plt.legend(loc='upper right')
     return plt.gcf()
 
 
@@ -178,7 +178,7 @@ def test_display_labeled_intervals_compare_common():
         est_int, est_labels, label_set=label_set, alpha=0.5, label="Estimate"
     )
 
-    plt.legend()
+    plt.legend(loc='upper right')
     return plt.gcf()
 
 
@@ -344,7 +344,7 @@ def test_display_piano_roll():
         est_t, est_p, label="Estimate", alpha=0.5, facecolor="r"
     )
 
-    plt.legend()
+    plt.legend(loc='upper right')
     return plt.gcf()
 
 
@@ -367,7 +367,7 @@ def test_display_piano_roll_midi():
         est_t, midi=est_midi, label="Estimate", alpha=0.5, facecolor="r"
     )
 
-    plt.legend()
+    plt.legend(loc='upper right')
     return plt.gcf()
 
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -151,7 +151,7 @@ def test_display_labeled_intervals_compare_noextend():
         est_int, est_labels, extend_labels=False, alpha=0.5, label="Estimate"
     )
 
-    plt.legend(loc='upper right')
+    plt.legend(loc="upper right")
     return plt.gcf()
 
 
@@ -178,7 +178,7 @@ def test_display_labeled_intervals_compare_common():
         est_int, est_labels, label_set=label_set, alpha=0.5, label="Estimate"
     )
 
-    plt.legend(loc='upper right')
+    plt.legend(loc="upper right")
     return plt.gcf()
 
 
@@ -344,7 +344,7 @@ def test_display_piano_roll():
         est_t, est_p, label="Estimate", alpha=0.5, facecolor="r"
     )
 
-    plt.legend(loc='upper right')
+    plt.legend(loc="upper right")
     return plt.gcf()
 
 
@@ -367,7 +367,7 @@ def test_display_piano_roll_midi():
         est_t, midi=est_midi, label="Estimate", alpha=0.5, facecolor="r"
     )
 
-    plt.legend(loc='upper right')
+    plt.legend(loc="upper right")
     return plt.gcf()
 
 


### PR DESCRIPTION
As of https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.9.0.html#miscellaneous-removals the tests fail because `matplotlib.collections.BrokenBarHCollection` has been removed now. This PR attempts to fix support for newer matplotlib versions.