### PR TITLE
Exact Interval-Based Segmentation Metrics

### DIFF
--- a/.github/environment.yml
+++ b/.github/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - pip
   - numpy >=1.20.3
   - scipy >=1.4.0
-  - matplotlib-base>=3.6.0
+  - matplotlib-base>=3.6.0,<3.11
   - pytest
   - pytest-cov
   - pytest-mpl

--- a/mir_eval/hierarchy.py
+++ b/mir_eval/hierarchy.py
@@ -674,8 +674,8 @@ def lmeasure(
         Like ``reference_intervals_hier`` and ``reference_labels_hier``
         but for the estimated annotation
     frame_size : float > 0 or None
-        length (in seconds) of frames.  The frame size cannot be longer than
-        the window. If None, use exact segment duration instead of framing.
+        length (in seconds) of frames.
+        If None, use exact segment duration instead of framing.
     beta : float > 0
         beta parameter for the F-measure.
 
@@ -695,15 +695,16 @@ def lmeasure(
 
         If the input hierarchies have different time durations
 
-        If ``frame_size > window`` or ``frame_size <= 0``
+        If ``frame_size <= 0``
     """
     # raise FutureWarning for change of default frame_size to None
-    warnings.warn(
-        "Default `frame_size` will change from 0.1 to None in a future version. "
-        "Set `frame_size` explicitly for consistent results.",
-        FutureWarning,
-        stacklevel=2,
-    )
+    if frame_size == 0.1:
+        warnings.warn(
+            "Default `frame_size` will change from 0.1 to None in a future version. "
+            "Set `frame_size` explicitly for consistent results.",
+            FutureWarning,
+            stacklevel=2,
+        )
 
     # Compute the number of frames in the window
     if frame_size is not None and frame_size <= 0:

--- a/mir_eval/hierarchy.py
+++ b/mir_eval/hierarchy.py
@@ -697,15 +697,6 @@ def lmeasure(
 
         If ``frame_size <= 0``
     """
-    # raise FutureWarning for change of default frame_size to None
-    if frame_size == 0.1:
-        warnings.warn(
-            "Default `frame_size` will change from 0.1 to None in a future version. "
-            "Set `frame_size` explicitly for consistent results.",
-            FutureWarning,
-            stacklevel=2,
-        )
-
     # Compute the number of frames in the window
     if frame_size is not None and frame_size <= 0:
         raise ValueError(

--- a/mir_eval/hierarchy.py
+++ b/mir_eval/hierarchy.py
@@ -232,6 +232,31 @@ def _meet(intervals_hier, labels_hier, frame_size):
     return scipy.sparse.csr_matrix(meet_matrix)
 
 
+def _common_intervals(*intervals_hiers):
+    """Construct atomic intervals from all hierarchy boundaries."""
+    all_boundaries = np.concatenate(
+        [
+            util.intervals_to_boundaries(intervals)
+            for intervals_hier in intervals_hiers
+            for intervals in intervals_hier
+        ]
+    )
+
+    return util.boundaries_to_intervals(np.unique(all_boundaries))
+
+
+def _meet_at_times(intervals_hier, labels_hier, times):
+    """Construct a meet matrix at the given time points."""
+    meet_matrix = np.zeros((len(times), len(times)), dtype=np.uint8)
+
+    for level, (intervals, labels) in enumerate(zip(intervals_hier, labels_hier), 1):
+        time_labels = util.interpolate_intervals(intervals, labels, times)
+        label_indices = util.index_labels(time_labels)[0]
+        meet_matrix[np.equal.outer(label_indices, label_indices)] = level
+
+    return meet_matrix
+
+
 def _gauc(ref_lca, est_lca, transitive, window):
     """Generalized area under the curve (GAUC)
 
@@ -327,10 +352,56 @@ def _gauc(ref_lca, est_lca, transitive, window):
     return score
 
 
-def _count_inversions(a, b):
-    """Count the number of inversions in two numpy arrays:
+def _gauc_frameless(ref_seg_meet, est_seg_meet, seg_durations, transitive):
+    """Compute duration-weighted GAUC over atomic intervals. See _gauc for details.
+
+    Parameters
+    ----------
+    ref_seg_meet : np.ndarray, shape=(n, n)
+        Reference meet matrix for atomic intervals
+    est_seg_meet : np.ndarray, shape=(n, n)
+        Estimated meet matrix for atomic intervals
+    seg_durations : np.ndarray, shape=(n,)
+        Duration of each atomic interval
+    transitive : bool
+        Whether to use transitive comparison
+
+    Returns
+    -------
+    score : float
+        Duration-weighted GAUC score
+    """
+    score = 0.0
+    total_weight = 0.0
+
+    for query, seg_duration in enumerate(seg_durations):
+        inversions, normalizer = _compare_frame_rankings(
+            ref_seg_meet[query],
+            est_seg_meet[query],
+            transitive=transitive,
+            index_weights=seg_durations,
+        )
+
+        if normalizer:
+            score += seg_duration * (1.0 - inversions / float(normalizer))
+            total_weight += seg_duration
+
+    # Preserve the existing _gauc convention: 0/0 -> 0.
+    if total_weight:
+        score /= total_weight
+    else:
+        score = 0.0
+
+    return score
+
+
+def _count_inversions(a, b, a_weights=None, b_weights=None):
+    """Count optionally weighted inversions between two arrays:
 
     # points i, j where a[i] >= b[j]
+
+    When weights are provided, each inversion contributes
+    `a_weights[i] * b_weights[j]` instead of one.
 
     Parameters
     ----------
@@ -340,15 +411,29 @@ def _count_inversions(a, b):
         This implementation is optimized for arrays with many
         repeated values.
 
+    a_weights, b_weights : np.ndarray, shape=(n,) (m,) or None
+        Optional weights for each element in a and b.
+        If provided, each inversion contributes `a_weights[i] * b_weights[j]`
+        instead of one.
+
     Returns
     -------
-    inversions : int
-        The number of detected inversions
+    inversions : float
+        The number of detected inversions, potentially weighted.
     """
-    a, a_counts = np.unique(a, return_counts=True)
-    b, b_counts = np.unique(b, return_counts=True)
+    if a_weights is None and b_weights is None:
+        # use the counts
+        a, a_counts = np.unique(a, return_counts=True)
+        b, b_counts = np.unique(b, return_counts=True)
+    else:
+        # get weighted counts by bincount
+        a, a_inverse = np.unique(a, return_inverse=True)
+        b, b_inverse = np.unique(b, return_inverse=True)
 
-    inversions = 0
+        a_counts = np.bincount(a_inverse, weights=a_weights)
+        b_counts = np.bincount(b_inverse, weights=b_weights)
+
+    inversions = 0.0
     i = 0
     j = 0
 
@@ -362,8 +447,8 @@ def _count_inversions(a, b):
     return inversions
 
 
-def _compare_frame_rankings(ref, est, transitive=False):
-    """Compute the number of ranking disagreements in two lists.
+def _compare_frame_rankings(ref, est, transitive=False, index_weights=None):
+    """Compute optionally weighted ranking disagreements between two lists.
 
     Parameters
     ----------
@@ -374,10 +459,15 @@ def _compare_frame_rankings(ref, est, transitive=False):
     transitive : bool
         If true, all pairs of reference levels are compared.
         If false, only adjacent pairs of reference levels are compared.
+    index_weights : np.ndarray, shape=(n,), optional
+        Non-negative weights associated with the indexed points. When
+        provided, each pair ``(i, j)`` contributes
+        ``index_weights[i] * index_weights[j]`` to the inversion count
+        and normalizer. If omitted, each pair contributes one.
 
     Returns
     -------
-    inversions : int
+    inversions : float
         The number of pairs of indices `i, j` where
         `ref[i] < ref[j]` but `est[i] >= est[j]`.
     normalizer : float
@@ -388,6 +478,9 @@ def _compare_frame_rankings(ref, est, transitive=False):
     idx = np.argsort(ref)
     ref_sorted = ref[idx]
     est_sorted = est[idx]
+
+    if index_weights is not None:
+        index_weights = index_weights[idx]
 
     # Find the break-points in ref_sorted
     levels, positions, counts = np.unique(
@@ -402,7 +495,10 @@ def _compare_frame_rankings(ref, est, transitive=False):
 
     for level, cnt, start, end in zip(levels, counts, positions[:-1], positions[1:]):
         index[level] = slice(start, end)
-        ref_map[level] = cnt
+        if index_weights is not None:
+            ref_map[level] = np.sum(index_weights[index[level]])
+        else:
+            ref_map[level] = cnt
 
     # Now that we have values sorted, apply the inversion-counter to
     # pairs of reference values
@@ -418,12 +514,20 @@ def _compare_frame_rankings(ref, est, transitive=False):
     if normalizer == 0:
         return 0, 0.0
 
-    inversions = 0
+    inversions = 0.0
 
     for level_1, level_2 in level_pairs:
-        inversions += _count_inversions(
-            est_sorted[index[level_1]], est_sorted[index[level_2]]
-        )
+        if index_weights is None:
+            inversions += _count_inversions(
+                est_sorted[index[level_1]], est_sorted[index[level_2]]
+            )
+        else:
+            inversions += _count_inversions(
+                est_sorted[index[level_1]],
+                est_sorted[index[level_2]],
+                a_weights=index_weights[index[level_1]],
+                b_weights=index_weights[index[level_2]],
+            )
 
     return inversions, float(normalizer)
 
@@ -569,9 +673,9 @@ def lmeasure(
     estimated_labels_hier : list of ndarray
         Like ``reference_intervals_hier`` and ``reference_labels_hier``
         but for the estimated annotation
-    frame_size : float > 0
+    frame_size : float > 0 or None
         length (in seconds) of frames.  The frame size cannot be longer than
-        the window.
+        the window. If None, use exact segment duration instead of framing.
     beta : float > 0
         beta parameter for the F-measure.
 
@@ -593,23 +697,50 @@ def lmeasure(
 
         If ``frame_size > window`` or ``frame_size <= 0``
     """
+    # raise FutureWarning for change of default frame_size to None
+    warnings.warn(
+        "Default `frame_size` will change from 0.1 to None in a future version. "
+        "Set `frame_size` explicitly for consistent results.",
+        FutureWarning,
+        stacklevel=2,
+    )
+
     # Compute the number of frames in the window
-    if frame_size <= 0:
+    if frame_size is not None and frame_size <= 0:
         raise ValueError(
-            "frame_size ({:.2f}) must be a positive " "number.".format(frame_size)
+            "frame_size ({:.2f}) must be a positive number or None.".format(frame_size)
         )
 
     # Validate the hierarchical segmentations
     validate_hier_intervals(reference_intervals_hier)
     validate_hier_intervals(estimated_intervals_hier)
 
-    # Build the least common ancestor matrices
-    ref_meet = _meet(reference_intervals_hier, reference_labels_hier, frame_size)
-    est_meet = _meet(estimated_intervals_hier, estimated_labels_hier, frame_size)
+    if frame_size is None:
+        atomic_intervals = _common_intervals(
+            reference_intervals_hier,
+            estimated_intervals_hier,
+        )
+        seg_durations = util.intervals_to_durations(atomic_intervals)
 
-    # Compute precision and recall
-    l_recall = _gauc(ref_meet, est_meet, True, None)
-    l_precision = _gauc(est_meet, ref_meet, True, None)
+        # build meet matrix at atomic interval midpoints
+        query_time = np.mean(atomic_intervals, axis=1)
+        ref_meet = _meet_at_times(
+            reference_intervals_hier, reference_labels_hier, query_time
+        )
+        est_meet = _meet_at_times(
+            estimated_intervals_hier, estimated_labels_hier, query_time
+        )
+
+        l_recall = _gauc_frameless(ref_meet, est_meet, seg_durations, True)
+        l_precision = _gauc_frameless(est_meet, ref_meet, seg_durations, True)
+    else:
+        # Build the least common ancestor matrices
+        ref_meet = _meet(reference_intervals_hier, reference_labels_hier, frame_size)
+        est_meet = _meet(estimated_intervals_hier, estimated_labels_hier, frame_size)
+
+        # Compute precision and recall
+        l_recall = _gauc(ref_meet, est_meet, True, None)
+        l_precision = _gauc(est_meet, ref_meet, True, None)
 
     l_measure = util.f_measure(l_precision, l_recall, beta=beta)
 

--- a/mir_eval/segment.py
+++ b/mir_eval/segment.py
@@ -369,12 +369,13 @@ def pairwise(
 
     """
     # raise FutureWarning for change of default frame_size to None
-    warnings.warn(
-        "Default `frame_size` will change from 0.1 to None in a future version. "
-        "Set `frame_size` explicitly for consistent results.",
-        FutureWarning,
-        stacklevel=2,
-    )
+    if frame_size == 0.1:
+        warnings.warn(
+            "Default `frame_size` will change from 0.1 to None in a future version. "
+            "Set `frame_size` explicitly for consistent results.",
+            FutureWarning,
+            stacklevel=2,
+        )
 
     validate_structure(
         reference_intervals, reference_labels, estimated_intervals, estimated_labels
@@ -572,13 +573,18 @@ def _contingency_matrix(reference_indices, estimated_indices, seg_durations=None
 
     # Optionally weight by segment duration
     if seg_durations is None:
-        seg_durations = np.ones(len(reference_indices))
-    # Using coo_matrix is faster than histogram2d
-    return scipy.sparse.coo_matrix(
-        (seg_durations, (ref_class_idx, est_class_idx)),
-        shape=(n_ref_classes, n_est_classes),
-        dtype=np.float64,
-    ).toarray()
+        # Using coo_matrix is faster than histogram2d
+        return scipy.sparse.coo_matrix(
+            (np.ones(ref_class_idx.shape[0]), (ref_class_idx, est_class_idx)),
+            shape=(n_ref_classes, n_est_classes),
+            dtype=np.int64,
+        ).toarray()
+    else:
+        return scipy.sparse.coo_matrix(
+            (seg_durations, (ref_class_idx, est_class_idx)),
+            shape=(n_ref_classes, n_est_classes),
+            dtype=np.float64,
+        ).toarray()
 
 
 def _adjusted_rand_index(reference_indices, estimated_indices):
@@ -1081,12 +1087,13 @@ def nce(
         F-measure for (S_over, S_under)
     """
     # raise FutureWarning for change of default frame_size to None
-    warnings.warn(
-        "Default `frame_size` will change from 0.1 to None in a future version. "
-        "Set `frame_size` explicitly for consistent results.",
-        FutureWarning,
-        stacklevel=2,
-    )
+    if frame_size == 0.1:
+        warnings.warn(
+            "Default `frame_size` will change from 0.1 to None in a future version. "
+            "Set `frame_size` explicitly for consistent results.",
+            FutureWarning,
+            stacklevel=2,
+        )
 
     validate_structure(
         reference_intervals, reference_labels, estimated_intervals, estimated_labels

--- a/mir_eval/segment.py
+++ b/mir_eval/segment.py
@@ -350,8 +350,9 @@ def pairwise(
     estimated_labels : list, shape=(m,)
         estimated segment labels, in the format returned by
         :func:`mir_eval.io.load_labeled_intervals`.
-    frame_size : float > 0
-        length (in seconds) of frames for clustering
+    frame_size : float > 0 or None
+        length (in seconds) of frames for clustering;
+        if None, use exact segment duration instead of frames
         (Default value = 0.1)
     beta : float > 0
         beta value for F-measure
@@ -367,6 +368,14 @@ def pairwise(
         F-measure of detecting whether frames belong in the same cluster
 
     """
+    # raise FutureWarning for change of default frame_size to None
+    warnings.warn(
+        "Default `frame_size` will change from 0.1 to None in a future version. "
+        "Set `frame_size` explicitly for consistent results.",
+        FutureWarning,
+        stacklevel=2,
+    )
+
     validate_structure(
         reference_intervals, reference_labels, estimated_intervals, estimated_labels
     )
@@ -376,32 +385,59 @@ def pairwise(
     if reference_intervals.size == 0 or estimated_intervals.size == 0:
         return 0.0, 0.0, 0.0
 
-    # Generate the cluster labels
-    y_ref = util.intervals_to_samples(
-        reference_intervals, reference_labels, sample_size=frame_size
-    )[-1]
+    if frame_size is None:
+        # Use the union of segment boundaries and exact segment duration
+        union_boundaries = util.intervals_to_boundaries(
+            np.vstack([reference_intervals, estimated_intervals])
+        )
+        common_itvl = util.boundaries_to_intervals(union_boundaries)
+        itvl_mid_points = np.mean(common_itvl, axis=1)
+        common_itvl_duration = util.intervals_to_durations(common_itvl)
+        itvl_dur_meet = np.outer(common_itvl_duration, common_itvl_duration)
 
-    y_ref = util.index_labels(y_ref)[0]
+        # Get the labels of the mid points of common intervals
+        y_ref = util.interpolate_intervals(
+            reference_intervals, reference_labels, itvl_mid_points
+        )
+        y_est = util.interpolate_intervals(
+            estimated_intervals, estimated_labels, itvl_mid_points
+        )
+    else:
+        # Generate the cluster labels by uniformly sampling
+        y_ref = util.intervals_to_samples(
+            reference_intervals, reference_labels, sample_size=frame_size
+        )[-1]
+
+        y_est = util.intervals_to_samples(
+            estimated_intervals, estimated_labels, sample_size=frame_size
+        )[-1]
 
     # Map to index space
-    y_est = util.intervals_to_samples(
-        estimated_intervals, estimated_labels, sample_size=frame_size
-    )[-1]
-
+    y_ref = util.index_labels(y_ref)[0]
     y_est = util.index_labels(y_est)[0]
 
     # Build the reference label agreement matrix
     agree_ref = np.equal.outer(y_ref, y_ref)
-    # Count the unique pairs
-    n_agree_ref = (agree_ref.sum() - len(y_ref)) / 2.0
+    if frame_size is not None:
+        # Count the unique pairs
+        n_agree_ref = (agree_ref.sum() - len(y_ref)) / 2.0
+    else:
+        # weight by interval duration: not excluding the diagonal as frame_size -> 0.
+        n_agree_ref = (agree_ref * itvl_dur_meet).sum()
 
     # Repeat for estimate
     agree_est = np.equal.outer(y_est, y_est)
-    n_agree_est = (agree_est.sum() - len(y_est)) / 2.0
+    if frame_size is not None:
+        n_agree_est = (agree_est.sum() - len(y_est)) / 2.0
+    else:
+        n_agree_est = (agree_est * itvl_dur_meet).sum()
 
     # Find where they agree
     matches = np.logical_and(agree_ref, agree_est)
-    n_matches = (matches.sum() - len(y_ref)) / 2.0
+    if frame_size is not None:
+        n_matches = (matches.sum() - len(y_ref)) / 2.0
+    else:
+        n_matches = (matches * itvl_dur_meet).sum()
 
     precision = n_matches / n_agree_est
     recall = n_matches / n_agree_ref
@@ -509,7 +545,7 @@ def rand_index(
     return rand
 
 
-def _contingency_matrix(reference_indices, estimated_indices):
+def _contingency_matrix(reference_indices, estimated_indices, seg_durations=None):
     """Compute the contingency matrix of a true labeling vs an estimated one.
 
     Parameters
@@ -518,6 +554,9 @@ def _contingency_matrix(reference_indices, estimated_indices):
         Array of reference indices
     estimated_indices : np.ndarray
         Array of estimated indices
+    seg_durations : np.ndarray or None.
+        Array of segment durations. If provided (not None), the contingency matrix will be
+        weighted by segment duration instead of counting occurrences.
 
     Returns
     -------
@@ -530,11 +569,15 @@ def _contingency_matrix(reference_indices, estimated_indices):
     est_classes, est_class_idx = np.unique(estimated_indices, return_inverse=True)
     n_ref_classes = ref_classes.shape[0]
     n_est_classes = est_classes.shape[0]
+
+    # Optionally weight by segment duration
+    if seg_durations is None:
+        seg_durations = np.ones(len(reference_indices))
     # Using coo_matrix is faster than histogram2d
     return scipy.sparse.coo_matrix(
-        (np.ones(ref_class_idx.shape[0]), (ref_class_idx, est_class_idx)),
+        (seg_durations, (ref_class_idx, est_class_idx)),
         shape=(n_ref_classes, n_est_classes),
-        dtype=np.int64,
+        dtype=np.float64,
     ).toarray()
 
 
@@ -1004,8 +1047,9 @@ def nce(
     estimated_labels : list, shape=(m,)
         estimated segment labels, in the format returned by
         :func:`mir_eval.io.load_labeled_intervals`.
-    frame_size : float > 0
+    frame_size : float > 0 or None
         length (in seconds) of frames for clustering
+        if None, use exact segment duration instead of frames
         (Default value = 0.1)
     beta : float > 0
         beta for F-measure
@@ -1036,6 +1080,14 @@ def nce(
     S_F
         F-measure for (S_over, S_under)
     """
+    # raise FutureWarning for change of default frame_size to None
+    warnings.warn(
+        "Default `frame_size` will change from 0.1 to None in a future version. "
+        "Set `frame_size` explicitly for consistent results.",
+        FutureWarning,
+        stacklevel=2,
+    )
+
     validate_structure(
         reference_intervals, reference_labels, estimated_intervals, estimated_labels
     )
@@ -1045,25 +1097,49 @@ def nce(
     if reference_intervals.size == 0 or estimated_intervals.size == 0:
         return 0.0, 0.0, 0.0
 
-    # Generate the cluster labels
-    y_ref = util.intervals_to_samples(
-        reference_intervals, reference_labels, sample_size=frame_size
-    )[-1]
+    if frame_size is None:
+        # Use the union of segment boundaries and exact segment duration
+        union_boundaries = util.intervals_to_boundaries(
+            np.vstack([reference_intervals, estimated_intervals])
+        )
+        common_itvl = util.boundaries_to_intervals(union_boundaries)
+        itvl_mid_points = np.mean(common_itvl, axis=1)
+        common_itvl_duration = util.intervals_to_durations(common_itvl)
 
-    y_ref = util.index_labels(y_ref)[0]
+        # Get the labels of the mid points of common intervals
+        y_ref = util.interpolate_intervals(
+            reference_intervals, reference_labels, itvl_mid_points
+        )
+        y_est = util.interpolate_intervals(
+            estimated_intervals, estimated_labels, itvl_mid_points
+        )
+    else:
+        # Generate the cluster labels by uniformly sampling
+        y_ref = util.intervals_to_samples(
+            reference_intervals, reference_labels, sample_size=frame_size
+        )[-1]
+
+        y_est = util.intervals_to_samples(
+            estimated_intervals, estimated_labels, sample_size=frame_size
+        )[-1]
+
+        common_itvl_duration = None
 
     # Map to index space
-    y_est = util.intervals_to_samples(
-        estimated_intervals, estimated_labels, sample_size=frame_size
-    )[-1]
-
+    y_ref = util.index_labels(y_ref)[0]
     y_est = util.index_labels(y_est)[0]
 
     # Make the contingency table: shape = (n_ref, n_est)
-    contingency = _contingency_matrix(y_ref, y_est).astype(float)
+    contingency = _contingency_matrix(
+        y_ref, y_est, seg_durations=common_itvl_duration
+    ).astype(float)
 
-    # Normalize by the number of frames
-    contingency = contingency / len(y_ref)
+    if frame_size is not None:
+        # Normalize by the number of frames
+        contingency = contingency / len(y_ref)
+    else:
+        # Normalize by the total duration
+        contingency = contingency / np.sum(common_itvl_duration)
 
     # Compute the marginals
     p_est = contingency.sum(axis=0)
@@ -1145,8 +1221,9 @@ def vmeasure(
     estimated_labels : list, shape=(m,)
         estimated segment labels, in the format returned by
         :func:`mir_eval.io.load_labeled_intervals`.
-    frame_size : float > 0
+    frame_size : float > 0 or None
         length (in seconds) of frames for clustering
+        if None, use exact segment duration instead of frames
         (Default value = 0.1)
     beta : float > 0
         beta for F-measure

--- a/mir_eval/segment.py
+++ b/mir_eval/segment.py
@@ -368,15 +368,6 @@ def pairwise(
         F-measure of detecting whether frames belong in the same cluster
 
     """
-    # raise FutureWarning for change of default frame_size to None
-    if frame_size == 0.1:
-        warnings.warn(
-            "Default `frame_size` will change from 0.1 to None in a future version. "
-            "Set `frame_size` explicitly for consistent results.",
-            FutureWarning,
-            stacklevel=2,
-        )
-
     validate_structure(
         reference_intervals, reference_labels, estimated_intervals, estimated_labels
     )
@@ -1086,15 +1077,6 @@ def nce(
     S_F
         F-measure for (S_over, S_under)
     """
-    # raise FutureWarning for change of default frame_size to None
-    if frame_size == 0.1:
-        warnings.warn(
-            "Default `frame_size` will change from 0.1 to None in a future version. "
-            "Set `frame_size` explicitly for consistent results.",
-            FutureWarning,
-            stacklevel=2,
-        )
-
     validate_structure(
         reference_intervals, reference_labels, estimated_intervals, estimated_labels
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,7 @@ docs =
     sphinx_rtd_theme
     matplotlib >= 3.6.0
 tests =
-    matplotlib >= 3.6.0
+    matplotlib >= 3.6.0, < 3.11
     pytest
     pytest-cov
     pytest-mpl

--- a/tests/test_hierarchy.py
+++ b/tests/test_hierarchy.py
@@ -89,7 +89,7 @@ def test_tmeasure_fail_frame_size(window, frame_size):
     mir_eval.hierarchy.tmeasure(ref, ref, window=window, frame_size=frame_size)
 
 
-@pytest.mark.parametrize("frame_size", [0.1, 0.5, 1.0])
+@pytest.mark.parametrize("frame_size", [0.1, 0.5, 1.0, None])
 def test_lmeasure_pass(frame_size):
     # The estimate here gets none of the structure correct.
     ref = [[[0, 30]], [[0, 15], [15, 30]]]
@@ -323,3 +323,151 @@ def test_compare_frame_rankings():
     inv, norm = mir_eval.hierarchy._compare_frame_rankings(ref, ref, transitive=True)
     assert inv == 0
     assert norm == 0.0
+
+
+def test_compare_frame_rankings_unit_weights():
+    ref = np.asarray([1, 2, 3, 3])
+    est = np.asarray([1, 2, 1, 3])
+
+    unweighted = mir_eval.hierarchy._compare_frame_rankings(ref, est, transitive=True)
+    weighted = mir_eval.hierarchy._compare_frame_rankings(
+        ref,
+        est,
+        transitive=True,
+        index_weights=np.ones(len(ref)),
+    )
+
+    assert weighted == unweighted
+
+
+def test_compare_frame_rankings_weighted():
+    ref = np.asarray([1, 2, 3, 3])
+    est = np.asarray([1, 2, 1, 3])
+    index_weights = np.asarray([1.0, 2.0, 3.0, 4.0])
+
+    # Total weights at each reference level:
+    #
+    # level 1: 1
+    # level 2: 2
+    # level 3: 3 + 4 = 7
+    #
+    # Transitive normalizer:
+    #   (1, 2): 1 * 2 = 2
+    #   (1, 3): 1 * 7 = 7
+    #   (2, 3): 2 * 7 = 14
+    #   total = 23
+    #
+    # No inversions when comparing ref against itself.
+    inv, norm = mir_eval.hierarchy._compare_frame_rankings(
+        ref,
+        ref,
+        transitive=True,
+        index_weights=index_weights,
+    )
+    assert inv == 0
+    assert norm == 23.0
+
+    # Non-transitive normalizer:
+    #   (1, 2): 1 * 2 = 2
+    #   (2, 3): 2 * 7 = 14
+    #   total = 16
+    inv, norm = mir_eval.hierarchy._compare_frame_rankings(
+        ref,
+        ref,
+        transitive=False,
+        index_weights=index_weights,
+    )
+    assert inv == 0
+    assert norm == 16.0
+
+    # For est = [1, 2, 1, 3], the weighted inversions are:
+    #
+    # Reference levels (1, 3):
+    #   est[0] >= est[2]: 1 >= 1
+    #   contribution = 1 * 3 = 3
+    #
+    # Reference levels (2, 3):
+    #   est[1] >= est[2]: 2 >= 1
+    #   contribution = 2 * 3 = 6
+    #
+    # Transitive total = 3 + 6 = 9
+    inv, norm = mir_eval.hierarchy._compare_frame_rankings(
+        ref,
+        est,
+        transitive=True,
+        index_weights=index_weights,
+    )
+    assert inv == 9.0
+    assert norm == 23.0
+
+    # Non-transitive comparisons exclude reference levels (1, 3),
+    # leaving only the inversion between levels (2, 3).
+    inv, norm = mir_eval.hierarchy._compare_frame_rankings(
+        ref,
+        est,
+        transitive=False,
+        index_weights=index_weights,
+    )
+    assert inv == 6.0
+    assert norm == 16.0
+
+    # A constant reference ranking has no ordered level pairs.
+    constant_ref = np.asarray([1, 1, 1, 1])
+
+    inv, norm = mir_eval.hierarchy._compare_frame_rankings(
+        constant_ref,
+        constant_ref,
+        transitive=True,
+        index_weights=index_weights,
+    )
+    assert inv == 0
+    assert norm == 0.0
+
+
+def test_lmeasure_frameless_simple():
+    ref_itvls = [
+        np.array([[0.0, 3.0]]),
+        np.array([[0.0, 2.0], [2.0, 3.0]]),
+    ]
+    ref_labels = [
+        ["A"],
+        ["x", "y"],
+    ]
+
+    est_itvls = [
+        np.array([[0.0, 3.0]]),
+        np.array([[0.0, 1.0], [1.0, 3.0]]),
+    ]
+    est_labels = [
+        ["B"],
+        ["c", "d"],
+    ]
+
+    score = mir_eval.hierarchy.lmeasure(
+        ref_itvls, ref_labels, est_itvls, est_labels, frame_size=None
+    )
+    assert np.allclose(score, (1 / 3, 1 / 3, 1 / 3), atol=A_TOL)
+
+
+def test_lmeasure_frameless_against_framed():
+
+    # Hierarchy data is split across multiple lab files for these tests
+    ref_files = sorted(glob.glob("data/hierarchy/ref*.lab"))
+    est_files = sorted(glob.glob("data/hierarchy/est*.lab"))
+
+    ref_hier = [mir_eval.io.load_labeled_intervals(_) for _ in ref_files]
+    est_hier = [mir_eval.io.load_labeled_intervals(_) for _ in est_files]
+
+    ref_ints = [seg[0] for seg in ref_hier]
+    ref_labs = [seg[1] for seg in ref_hier]
+    est_ints = [seg[0] for seg in est_hier]
+    est_labs = [seg[1] for seg in est_hier]
+
+    framed_outputs = mir_eval.hierarchy.lmeasure(
+        ref_ints, ref_labs, est_ints, est_labs, frame_size=0.1
+    )
+    frameless_outputs = mir_eval.hierarchy.lmeasure(
+        ref_ints, ref_labs, est_ints, est_labs, frame_size=None
+    )
+
+    assert np.allclose(framed_outputs, frameless_outputs, atol=0.01)

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -214,3 +214,29 @@ def test_segment_functions_permuted(segment_data):
     assert scores.keys() == expected_scores.keys()
     for metric in scores:
         assert np.allclose(scores[metric], expected_scores[metric], atol=A_TOL)
+
+
+def test_frameless_pairwise():
+    # Test that pairwise works with frame_size=None
+    ref_intervals = np.array([[0, 1], [1, 2], [2, 3]])
+    ref_labels = ["a", "b", "a"]
+    est_intervals = np.array([[0, 2], [2, 3]])
+    est_labels = ["a", "b"]
+
+    score = mir_eval.segment.pairwise(
+        ref_intervals, ref_labels, est_intervals, est_labels, frame_size=None
+    )
+    assert np.allclose(score, (0.6, 0.6, 0.6), atol=A_TOL)
+
+
+def test_frameless_nce():
+    # Test that nce works with frame_size=None
+    ref_intervals = np.array([[0, 1], [1, 2], [2, 3]])
+    ref_labels = ["a", "b", "a"]
+    est_intervals = np.array([[0, 2], [2, 3]])
+    est_labels = ["a", "b"]
+
+    score = mir_eval.segment.nce(
+        ref_intervals, ref_labels, est_intervals, est_labels, frame_size=None
+    )
+    assert np.allclose(score, (1 / 3, 1 / 3, 1 / 3), atol=A_TOL)


### PR DESCRIPTION
Implements issue #432.

Adds `frame_size=None` as an option for the following segmentation metrics: `segment.pairwise`, `segment.nce`, `segment.vmeasure`, and `hierarchy.lmeasure`: this option will calculate these metrics without using framing/sampling, thus provide more accurate results and are generally much faster.

Also capped the matplotlib version in github workflow to be less than 3.11, so that the display tests are passing: matplotlib 3.11 seems to have made very subtle changes to plot axis text layouts, and thus the display tests are not passing against the reference plots if using mpl 3.11.